### PR TITLE
chore: refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - run: rustup update stable && rustup default stable
       - run: rustup toolchain install nightly -c rustfmt
       - run: git submodule update --init --recursive
@@ -41,9 +38,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - run: rustup update stable && rustup default stable
       - run: rustup toolchain install nightly -c rustfmt
       - run: git submodule update --init --recursive
@@ -58,9 +52,6 @@ jobs:
   #     - uses: actions/checkout@v4
   #     - name: Run sccache-cache
   #       uses: mozilla-actions/sccache-action@v0.0.4
-  #     - uses: pnpm/action-setup@v4
-  #       with:
-  #         version: 9
   #     - run: rustup update stable && rustup default stable
   #     - run: rustup target add wasm32-unknown-unknown
   #     - run: git submodule update --init --recursive
@@ -78,9 +69,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - run: rustup update stable && rustup default stable
       - run: git submodule update --init --recursive
       - run: make setup-thirdparty

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "crates/yttrium/safe-modules"]
 	path = crates/yttrium/safe-modules
 	url = https://github.com/safe-global/safe-modules
-[submodule "crates/yttrium/safe7579"]
-	path = crates/yttrium/safe7579
-	url = https://github.com/rhinestonewtf/safe7579
 [submodule "test/scripts/forked_state/mock-aa-environment"]
 	path = test/scripts/forked_state/mock-aa-environment
 	url = https://github.com/WalletConnect/mock-aa-environment.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ resolver = "2"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.79"
+license = "Apache-2.0"
 
 [workspace.dependencies]
 # Errors/Result

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 reown inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,6 @@ fetch-thirdparty:
 setup-thirdparty:
 	cd crates/yttrium/src/contracts/ && yarn install --frozen-lockfile --immutable && yarn compile
 	cd crates/yttrium/safe-smart-account/ && npm install
-	cd crates/yttrium/safe-modules/ && pnpm install
 
 build-ios-bindings:
 	sh crates/ffi/build-rust-ios.sh

--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ To contribute to this project, ensure you have the following dependencies instal
 - `make`
 - `just`
 - `npm`
-- `pnpm`
 - `yarn`
 
 ### Setup

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "cli"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -3,6 +3,7 @@ name = "ffi"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
 
 [lib]
 crate-type = ["staticlib"]

--- a/crates/yttrium/Cargo.toml
+++ b/crates/yttrium/Cargo.toml
@@ -3,6 +3,7 @@ name = "yttrium"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
 
 [features]
 full = []

--- a/crates/yttrium/build.rs
+++ b/crates/yttrium/build.rs
@@ -16,33 +16,6 @@ fn build_contracts() {
     );
 
     {
-        println!("cargo::rerun-if-changed=safe7579/pnpm-lock.yaml");
-        let output = Command::new("pnpm")
-            .current_dir("safe7579")
-            .args(["install"])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .unwrap()
-            .wait_with_output()
-            .unwrap();
-        println!("`pnpm install` status: {:?}", output.status);
-        let stdout = String::from_utf8(output.stdout).unwrap();
-        println!("`pnpm install` stdout: {stdout:?}");
-        let stderr = String::from_utf8(output.stderr).unwrap();
-        println!("`pnpm install` stderr: {stderr:?}");
-        assert!(output.status.success());
-    }
-    compile_contracts_with_args(
-        "safe7579/src/Safe7579Launchpad.sol",
-        &["--config-path=safe7579/foundry.toml".to_owned()],
-    );
-    compile_contracts_with_args(
-        "safe7579/src/Safe7579.sol",
-        &["--config-path=safe7579/foundry.toml".to_owned()],
-    );
-
-    {
         println!("cargo::rerun-if-changed=src/contracts/yarn.lock");
         let output = Command::new("yarn")
             .current_dir("src/contracts")

--- a/crates/yttrium/build.rs
+++ b/crates/yttrium/build.rs
@@ -1,7 +1,4 @@
-use {
-    // serde_json::Value,
-    std::process::{Command, Stdio},
-};
+use std::process::{Command, Stdio};
 
 fn main() {
     build_contracts();
@@ -9,17 +6,17 @@ fn main() {
 
 fn build_contracts() {
     install_foundry();
-    compile_contracts("crates/yttrium/safe-smart-account/contracts/proxies/SafeProxyFactory.sol", );
-    compile_contracts("crates/yttrium/safe-smart-account/contracts/Safe.sol");
     compile_contracts(
-        "crates/yttrium/safe-smart-account/contracts/libraries/MultiSend.sol",
+        "safe-smart-account/contracts/proxies/SafeProxyFactory.sol",
     );
+    compile_contracts("safe-smart-account/contracts/Safe.sol");
+    compile_contracts("safe-smart-account/contracts/libraries/MultiSend.sol");
     compile_contracts(
         "safe-modules/modules/4337/contracts/SafeModuleSetup.sol",
     );
 
     {
-        println!("cargo::rerun-if-changed=safe7579");
+        println!("cargo::rerun-if-changed=safe7579/pnpm-lock.yaml");
         let output = Command::new("pnpm")
             .current_dir("safe7579")
             .args(["install"])
@@ -46,7 +43,7 @@ fn build_contracts() {
     );
 
     {
-        println!("cargo::rerun-if-changed=src/contracts");
+        println!("cargo::rerun-if-changed=src/contracts/yarn.lock");
         let output = Command::new("yarn")
             .current_dir("src/contracts")
             .args(["install"])

--- a/crates/yttrium/src/bundler/client.rs
+++ b/crates/yttrium/src/bundler/client.rs
@@ -269,7 +269,7 @@ mod tests {
         let bundler_client = setup_gas_estimation_bundler_mock().await?;
 
         let user_op = {
-            let sender: Address = sender;
+            let sender = sender.into();
             let nonce: U256 = U256::from(0);
             let factory: Address = Address::ZERO;
             let factory_data: Bytes = Bytes::new();

--- a/crates/yttrium/src/bundler/pimlico/client.rs
+++ b/crates/yttrium/src/bundler/pimlico/client.rs
@@ -21,14 +21,13 @@ impl BundlerClient {
 
         use serde_json;
 
-        use crate::jsonrpc::{
-            JSONRPCResponse, RequestWithEmptyParams, Response,
-        };
+        use crate::jsonrpc::{JSONRPCResponse, Request, Response};
 
-        let req_body = RequestWithEmptyParams {
+        let req_body = Request {
             jsonrpc: "2.0".into(),
             id: 1,
             method: "pimlico_getUserOperationGasPrice".into(),
+            params: [] as [(); 0],
         };
         println!("req_body: {:?}", serde_json::to_string(&req_body)?);
 
@@ -74,6 +73,7 @@ mod tests {
             "id": 1,
             "jsonrpc": "2.0",
             "method": "pimlico_getUserOperationGasPrice",
+            "params": [],
         });
 
         let response_gas_price = GasPrice {

--- a/crates/yttrium/src/bundler/pimlico/paymaster/models.rs
+++ b/crates/yttrium/src/bundler/pimlico/paymaster/models.rs
@@ -39,7 +39,7 @@ pub struct UserOperationPreSponsorshipV07 {
 impl From<UserOperationV07> for UserOperationPreSponsorshipV07 {
     fn from(user_op: UserOperationV07) -> Self {
         Self {
-            sender: user_op.sender,
+            sender: user_op.sender.into(),
             nonce: user_op.nonce,
             factory: user_op.factory,
             factory_data: user_op.factory_data,

--- a/crates/yttrium/src/chain.rs
+++ b/crates/yttrium/src/chain.rs
@@ -1,7 +1,7 @@
 use crate::entry_point::{EntryPointConfig, EntryPointVersion};
 use std::fmt;
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ChainId(u64);
 
 impl ChainId {
@@ -123,7 +123,7 @@ impl Chain {
 impl Chain {
     pub fn entry_point_config(&self) -> EntryPointConfig {
         EntryPointConfig {
-            chain_id: self.id.clone(),
+            chain_id: self.id,
             version: self.entry_point_version,
         }
     }

--- a/crates/yttrium/src/chain.rs
+++ b/crates/yttrium/src/chain.rs
@@ -9,6 +9,8 @@ impl ChainId {
 
     pub const ETHEREUM_SEPOLIA: Self = Self::new_eip155(11155111);
 
+    pub const BASE_SEPOLIA: Self = Self::new_eip155(84532);
+
     pub const LOCAL_FOUNDRY_ETHEREUM_SEPOLIA: Self = Self::new_eip155(31337);
 
     pub const fn new_eip155(id: u64) -> Self {
@@ -99,6 +101,12 @@ impl Chain {
         id: ChainId::ETHEREUM_SEPOLIA,
         entry_point_version: EntryPointVersion::V07,
         name: "Ethereum Sepolia",
+    };
+
+    pub const BASE_SEPOLIA_V07: Self = Self {
+        id: ChainId::BASE_SEPOLIA,
+        entry_point_version: EntryPointVersion::V07,
+        name: "Base Sepolia",
     };
 
     pub const ETHEREUM_SEPOLIA_V06: Self = Self {

--- a/crates/yttrium/src/entry_point.rs
+++ b/crates/yttrium/src/entry_point.rs
@@ -1,5 +1,8 @@
 use crate::chain::ChainId;
-use alloy::sol;
+use alloy::{
+    primitives::{address, Address},
+    sol,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EntryPointAddress(alloy::primitives::Address);
@@ -32,10 +35,10 @@ impl From<&EntryPointAddress> for alloy::primitives::Address {
     }
 }
 
-pub const ENTRYPOINT_ADDRESS_V06: &str =
-    "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789";
-pub const ENTRYPOINT_ADDRESS_V07: &str =
-    "0x0000000071727De22E5E9d8BAf0edAc6f37da032";
+pub const ENTRYPOINT_ADDRESS_V06: Address =
+    address!("5FF137D4b0FDCD49DcA30c7CF57E578a026d2789");
+pub const ENTRYPOINT_ADDRESS_V07: Address =
+    address!("0000000071727De22E5E9d8BAf0edAc6f37da032");
 
 pub const ENTRYPOINT_V06_TYPE: &str = "v0.6";
 pub const ENTRYPOINT_V07_TYPE: &str = "v0.7";
@@ -85,18 +88,15 @@ impl EntryPointConfig {
     };
 
     pub fn address(&self) -> EntryPointAddress {
-        match self.chain_id {
-            ChainId::ETHEREUM_MAINNET
-            | ChainId::ETHEREUM_SEPOLIA
-            | ChainId::LOCAL_FOUNDRY_ETHEREUM_SEPOLIA => match self.version {
-                EntryPointVersion::V06 => EntryPointAddress::new(
-                    ENTRYPOINT_ADDRESS_V06.parse().unwrap(),
-                ),
-                EntryPointVersion::V07 => EntryPointAddress::new(
-                    ENTRYPOINT_ADDRESS_V07.parse().unwrap(),
-                ),
-            },
-            _ => panic!("Unsupported chain ID"),
+        // assuming that the entrypoint address is the same for all chains, so
+        // not matching based on `chain_id` (anymore)
+        match self.version {
+            EntryPointVersion::V06 => {
+                EntryPointAddress::new(ENTRYPOINT_ADDRESS_V06)
+            }
+            EntryPointVersion::V07 => {
+                EntryPointAddress::new(ENTRYPOINT_ADDRESS_V07)
+            }
         }
     }
 
@@ -147,14 +147,12 @@ impl From<String> for EntryPointVersion {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy::primitives::Address;
     use eyre;
 
     #[test]
     fn test_address_type() -> eyre::Result<()> {
         {
-            let expected_v06_address: Address =
-                ENTRYPOINT_ADDRESS_V06.parse().unwrap();
+            let expected_v06_address = ENTRYPOINT_ADDRESS_V06;
             let v06 = EntryPointVersion::V06;
             let mainnet_config = EntryPointConfig {
                 chain_id: ChainId::ETHEREUM_MAINNET,
@@ -168,8 +166,7 @@ mod tests {
         };
 
         {
-            let expected_v07_address: Address =
-                ENTRYPOINT_ADDRESS_V07.parse().unwrap();
+            let expected_v07_address = ENTRYPOINT_ADDRESS_V07;
             let v07 = EntryPointVersion::V07;
             let mainnet_config = EntryPointConfig {
                 chain_id: ChainId::ETHEREUM_MAINNET,
@@ -183,8 +180,7 @@ mod tests {
         };
 
         {
-            let expected_v07_address: Address =
-                ENTRYPOINT_ADDRESS_V07.parse().unwrap();
+            let expected_v07_address = ENTRYPOINT_ADDRESS_V07;
             let v07 = EntryPointVersion::V07;
             let local_sepolia_config = EntryPointConfig {
                 chain_id: ChainId::LOCAL_FOUNDRY_ETHEREUM_SEPOLIA,

--- a/crates/yttrium/src/entry_point/get_sender_address.rs
+++ b/crates/yttrium/src/entry_point/get_sender_address.rs
@@ -1,3 +1,4 @@
+use crate::smart_accounts::account_address::AccountAddress;
 use alloy::{
     contract::Error as ContractError,
     primitives::{Address, Bytes},
@@ -43,7 +44,7 @@ pub async fn get_sender_address_v07<P, T, N>(
     factory: Address,
     factory_data: Bytes,
     entrypoint: super::EntryPointAddress,
-) -> eyre::Result<Address>
+) -> eyre::Result<AccountAddress>
 where
     T: alloy::contract::private::Transport + ::core::clone::Clone,
     P: alloy::contract::private::Provider<T, N>,
@@ -113,7 +114,7 @@ where
 
                     println!("addr: {:?}", addr.clone());
 
-                    return Ok(addr);
+                    return Ok(addr.into());
                 } else {
                     return Err(eyre::eyre!("No data in error response"));
                 };

--- a/crates/yttrium/src/erc7579/mod.rs
+++ b/crates/yttrium/src/erc7579/mod.rs
@@ -1,0 +1,1 @@
+pub mod smart_sessions;

--- a/crates/yttrium/src/erc7579/smart_sessions/mod.rs
+++ b/crates/yttrium/src/erc7579/smart_sessions/mod.rs
@@ -1,0 +1,52 @@
+use alloy::sol;
+
+sol! {
+    struct ChainDigest {
+        uint64 chainId;
+        bytes32 sessionDigest;
+    }
+
+    struct PolicyData {
+        address policy;
+        bytes initData;
+    }
+
+    struct ERC7739Data {
+        string[] allowedERC7739Content;
+        PolicyData[] erc1271Policies;
+    }
+
+    struct ActionData {
+        bytes4 actionTargetSelector;
+        address actionTarget;
+        PolicyData[] actionPolicies;
+    }
+
+    struct Session {
+        address sessionValidator;
+        bytes sessionValidatorInitData;
+        bytes32 salt;
+        PolicyData[] userOpPolicies;
+        ERC7739Data erc7739Policies;
+        ActionData[] actions;
+    }
+
+    // https://github.com/erc7579/smartsessions/blob/b1624f851f56ec67cc677dce129e9caa12fcafd9/contracts/DataTypes.sol#L14
+    struct EnableSession {
+        uint8 chainDigestIndex;
+        ChainDigest[] hashesAndChainIds;
+        Session sessionToEnable;
+        bytes permissionEnableSig;
+    }
+
+    function enableSessionSig(EnableSession session, bytes signature);
+}
+
+sol! {
+    type PermissionId is bytes32;
+
+    #[sol(rpc)]
+    contract ISmartSession {
+        function isSessionEnabled(PermissionId permissionId, address account) external view returns (bool);
+    }
+}

--- a/crates/yttrium/src/lib.rs
+++ b/crates/yttrium/src/lib.rs
@@ -5,6 +5,7 @@ pub mod chain;
 pub mod config;
 pub mod eip7702;
 pub mod entry_point;
+pub mod erc7579;
 pub mod error;
 pub mod jsonrpc;
 pub mod private_key_service;

--- a/crates/yttrium/src/signer.rs
+++ b/crates/yttrium/src/signer.rs
@@ -86,7 +86,7 @@ impl Signer {
         chain_id: u64,
         sign_service: &MutexGuard<SignService>,
     ) -> eyre::Result<UserOperationV07> {
-        let hash = uo.hash(ep, chain_id)?;
+        let hash = uo.hash(ep, chain_id);
         let message_bytes = hash.0.to_vec();
         println!("message_bytes: {:?}", message_bytes.clone());
 
@@ -152,7 +152,7 @@ pub fn sign_user_operation_v07_with_ecdsa_and_sign_service(
     signer: PrivateKeySigner,
     sign_service: &Arc<Mutex<SignService>>,
 ) -> eyre::Result<UserOperationV07> {
-    let hash = uo.hash(ep, chain_id)?;
+    let hash = uo.hash(ep, chain_id);
 
     println!("hash: {:?}", hash.clone());
 
@@ -204,7 +204,7 @@ pub fn sign_user_operation_v07_with_ecdsa(
     chain_id: u64,
     signer: PrivateKeySigner,
 ) -> eyre::Result<UserOperationV07> {
-    let hash = uo.hash(ep, chain_id)?;
+    let hash = uo.hash(ep, chain_id);
 
     println!("hash: {:?}", hash.clone());
 

--- a/crates/yttrium/src/smart_accounts.rs
+++ b/crates/yttrium/src/smart_accounts.rs
@@ -1,3 +1,4 @@
+pub mod account_address;
 pub mod deployed;
 pub mod nonce;
 pub mod safe;

--- a/crates/yttrium/src/smart_accounts/account_address.rs
+++ b/crates/yttrium/src/smart_accounts/account_address.rs
@@ -1,0 +1,44 @@
+use alloy::primitives::Address;
+use serde::{Deserialize, Serialize};
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Ord,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+    Default,
+)]
+pub struct AccountAddress(Address);
+
+impl AccountAddress {
+    pub fn new(address: Address) -> Self {
+        Self(address)
+    }
+
+    pub fn to_address(&self) -> Address {
+        self.0
+    }
+}
+
+impl From<AccountAddress> for Address {
+    fn from(val: AccountAddress) -> Self {
+        val.0
+    }
+}
+
+impl From<Address> for AccountAddress {
+    fn from(val: Address) -> Self {
+        Self::new(val)
+    }
+}
+
+impl std::fmt::Display for AccountAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/crates/yttrium/src/smart_accounts/deployed.rs
+++ b/crates/yttrium/src/smart_accounts/deployed.rs
@@ -1,19 +1,18 @@
-use alloy::{
-    contract::private::{Network, Provider, Transport},
-    primitives::Address,
-};
+use super::account_address::AccountAddress;
+use alloy::contract::private::{Network, Provider, Transport};
 use core::clone::Clone;
 
 pub async fn is_smart_account_deployed<P, T, N>(
     provider: &P,
-    sender_address: Address,
+    sender_address: AccountAddress,
 ) -> eyre::Result<bool>
 where
     T: Transport + Clone,
     P: Provider<T, N>,
     N: Network,
 {
-    let contract_code = provider.get_code_at(sender_address).await?;
+    let contract_code =
+        provider.get_code_at(sender_address.to_address()).await?;
 
     if contract_code.len() > 2 {
         return Ok(true);

--- a/crates/yttrium/src/smart_accounts/safe.rs
+++ b/crates/yttrium/src/smart_accounts/safe.rs
@@ -25,20 +25,53 @@ sol!(
     ".foundry/forge/out/Safe.sol/Safe.json"
 );
 
-sol!(
-    #[allow(clippy::too_many_arguments)]
-    #[allow(missing_docs)]
-    #[sol(rpc)]
-    Safe7579Launchpad,
-    ".foundry/forge/out/Safe7579Launchpad.sol/Safe7579Launchpad.json"
-);
+sol! {
+    contract Safe7579Launchpad {
+        struct ModuleInit {
+            address module;
+            bytes initData;
+        }
 
-sol!(
-    #[allow(missing_docs)]
-    #[sol(rpc)]
-    Safe7579,
-    ".foundry/forge/out/Safe7579.sol/Safe7579.json"
-);
+        struct InitData {
+            address singleton;
+            address[] owners;
+            uint256 threshold;
+            address setupTo;
+            bytes setupData;
+            address safe7579;
+            ModuleInit[] validators;
+            bytes callData;
+        }
+
+        function initSafe7579(
+            address safe7579,
+            ModuleInit[] calldata executors,
+            ModuleInit[] calldata fallbacks,
+            ModuleInit[] calldata hooks,
+            address[] calldata attesters,
+            uint8 threshold
+        );
+
+        function setupSafe(InitData calldata initData);
+
+        function preValidationSetup(
+            bytes32 initHash,
+            address to,
+            bytes calldata preInit
+        );
+    }
+}
+
+sol! {
+    contract Safe7579 {
+        type ModeCode is bytes32;
+
+        function execute(
+            ModeCode mode,
+            bytes calldata executionCalldata
+        );
+    }
+}
 
 // https://github.com/WalletConnect/secure-web3modal/blob/f1d16f973a313e598d124a0e4751aee12d5de628/src/core/SmartAccountSdk/utils.ts#L180
 pub const SAFE_ERC_7579_LAUNCHPAD_ADDRESS: Address =

--- a/crates/yttrium/src/smart_accounts/safe.rs
+++ b/crates/yttrium/src/smart_accounts/safe.rs
@@ -1,3 +1,4 @@
+use crate::smart_accounts::account_address::AccountAddress;
 use crate::transaction::Transaction;
 use alloy::{
     dyn_abi::DynSolValue,
@@ -152,7 +153,7 @@ pub fn factory_data(
 pub async fn get_account_address(
     provider: ReqwestProvider,
     owners: Owners,
-) -> Address {
+) -> AccountAddress {
     let creation_code =
         SafeProxyFactory::new(SAFE_PROXY_FACTORY_ADDRESS, provider.clone())
             .proxyCreationCode()
@@ -179,7 +180,7 @@ pub async fn get_account_address(
         ])
         .abi_encode_packed(),
     );
-    SAFE_PROXY_FACTORY_ADDRESS.create2(salt, keccak256(deployment_code))
+    SAFE_PROXY_FACTORY_ADDRESS.create2(salt, keccak256(deployment_code)).into()
 }
 
 pub fn get_call_data(execution_calldata: Vec<Transaction>) -> Bytes {

--- a/crates/yttrium/src/smart_accounts/safe.rs
+++ b/crates/yttrium/src/smart_accounts/safe.rs
@@ -1,6 +1,9 @@
+use crate::transaction::Transaction;
 use alloy::{
     dyn_abi::DynSolValue,
-    primitives::{address, keccak256, Address, Bytes, Uint, U256},
+    primitives::{
+        address, bytes, keccak256, Address, Bytes, FixedBytes, Uint, U256,
+    },
     providers::ReqwestProvider,
     sol,
     sol_types::{SolCall, SolValue},
@@ -34,18 +37,6 @@ sol!(
     #[sol(rpc)]
     Safe7579,
     ".foundry/forge/out/Safe7579.sol/Safe7579.json"
-);
-
-// Had to copy from safe7579/artifacts/interfaces/IERC7579Account.json
-// This struct doesn't seem to be in generated ABIs
-sol!(
-    #[allow(missing_docs)]
-    #[sol(rpc, abi)]
-    struct Execution {
-        address target;
-        uint256 value;
-        bytes callData;
-    }
 );
 
 // https://github.com/WalletConnect/secure-web3modal/blob/f1d16f973a313e598d124a0e4751aee12d5de628/src/core/SmartAccountSdk/utils.ts#L180
@@ -93,7 +84,7 @@ sol!(
     ".foundry/forge/out/MultiSend.sol/MultiSend.json"
 );
 
-pub const DUMMY_SIGNATURE_HEX: &str = "0x000000000000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+pub const DUMMY_SIGNATURE: Bytes = bytes!("000000000000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 
 // https://github.com/WalletConnect/secure-web3modal/blob/c19a1e7b21c6188261728f4d521a17f94da4f055/src/core/SmartAccountSdk/constants.ts#L10
 // const APPKIT_SALT: U256 = U256::from_str("zg3ijy0p46");
@@ -189,4 +180,147 @@ pub async fn get_account_address(
         .abi_encode_packed(),
     );
     SAFE_PROXY_FACTORY_ADDRESS.create2(salt, keccak256(deployment_code))
+}
+
+pub fn get_call_data(execution_calldata: Vec<Transaction>) -> Bytes {
+    let batch = execution_calldata.len() != 1;
+    let revert_on_error = false;
+    let selector = [0u8; 4];
+    let context = [0u8; 22];
+
+    let mode = DynSolValue::Tuple(vec![
+        DynSolValue::Uint(Uint::from(if batch { 0x01 } else { 0x00 }), 8), // DelegateCall is 0xFF
+        DynSolValue::Uint(Uint::from(revert_on_error as u8), 8),
+        DynSolValue::Bytes(vec![0u8; 4]),
+        DynSolValue::Bytes(selector.to_vec()),
+        DynSolValue::Bytes(context.to_vec()),
+    ])
+    .abi_encode_packed();
+
+    let execution_calldata = encode_calls(execution_calldata);
+
+    Safe7579::executeCall {
+        mode: FixedBytes::from_slice(&mode),
+        executionCalldata: execution_calldata,
+    }
+    .abi_encode()
+    .into()
+}
+
+sol! {
+    function executionBatch((address, uint256, bytes)[]);
+}
+
+fn encode_calls(calls: Vec<Transaction>) -> Bytes {
+    fn call(call: Transaction) -> (Address, U256, Bytes) {
+        (call.to, call.value, call.data)
+    }
+
+    let tuples = calls.into_iter().map(call).collect::<Vec<_>>();
+    if tuples.len() == 1 {
+        tuples.abi_encode_packed()
+    } else {
+        let call = executionBatchCall { _0: tuples };
+
+        // encode without selector
+        let mut out = Vec::with_capacity(call.abi_encoded_size());
+        call.abi_encode_raw(&mut out);
+        out
+    }
+    .into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_execution_call_data() {
+        assert_eq!(encode_calls(vec![]), bytes!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000"));
+    }
+
+    #[test]
+    fn single_execution_call_data_value() {
+        assert_eq!(
+            encode_calls(vec![Transaction {
+                to: address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                value: U256::from(19191919),
+                data: bytes!(""),
+            }]),
+            bytes!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa000000000000000000000000000000000000000000000000000000000124d86f")
+        );
+    }
+
+    #[test]
+    fn single_execution_call_data_data() {
+        assert_eq!(
+            encode_calls(vec![Transaction {
+                to: address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                value: U256::ZERO,
+                data: bytes!("7777777777777777"),
+            }]),
+            bytes!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00000000000000000000000000000000000000000000000000000000000000007777777777777777")
+        );
+    }
+
+    #[test]
+    fn two_execution_call_data() {
+        assert_eq!(
+            encode_calls(vec![Transaction {
+                to: address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                value: U256::from(19191919),
+                data: bytes!(""),
+            }, Transaction {
+                to: address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                value: U256::ZERO,
+                data: bytes!("7777777777777777"),
+            }]),
+            bytes!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa000000000000000000000000000000000000000000000000000000000124d86f00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000087777777777777777000000000000000000000000000000000000000000000000")
+        );
+    }
+
+    #[test]
+    fn empty_call_data() {
+        assert_eq!(get_call_data(vec![]), bytes!("e9ae5c5301000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000"));
+    }
+
+    #[test]
+    fn single_call_data_value() {
+        assert_eq!(
+            get_call_data(vec![Transaction {
+                to: address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                value: U256::from(19191919),
+                data: bytes!(""),
+            }]),
+            bytes!("e9ae5c53000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000034aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa000000000000000000000000000000000000000000000000000000000124d86f000000000000000000000000")
+        );
+    }
+
+    #[test]
+    fn single_call_data_data() {
+        assert_eq!(
+            get_call_data(vec![Transaction {
+                to: address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                value: U256::ZERO,
+                data: bytes!("7777777777777777"),
+            }]),
+            bytes!("e9ae5c5300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000003caaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000000000000000000000000000000000000000000000000000000777777777777777700000000")
+        );
+    }
+
+    #[test]
+    fn two_call_data() {
+        assert_eq!(
+            get_call_data(vec![Transaction {
+                to: address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                value: U256::from(19191919),
+                data: bytes!(""),
+            }, Transaction {
+                to: address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                value: U256::ZERO,
+                data: bytes!("7777777777777777"),
+            }]),
+            bytes!("e9ae5c530100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000001a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa000000000000000000000000000000000000000000000000000000000124d86f00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000087777777777777777000000000000000000000000000000000000000000000000")
+        );
+    }
 }

--- a/crates/yttrium/src/smart_accounts/simple_account.rs
+++ b/crates/yttrium/src/smart_accounts/simple_account.rs
@@ -35,25 +35,6 @@ sol!(
 pub const DUMMY_SIGNATURE_HEX: &str = "0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct SimpleAccountAddress(alloy::primitives::Address);
-
-impl SimpleAccountAddress {
-    pub fn new(address: alloy::primitives::Address) -> Self {
-        Self(address)
-    }
-
-    pub fn to_address(&self) -> alloy::primitives::Address {
-        self.0
-    }
-}
-
-impl From<SimpleAccountAddress> for alloy::primitives::Address {
-    fn from(val: SimpleAccountAddress) -> Self {
-        val.0
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct OwnerAddress(alloy::primitives::Address);
 
 impl OwnerAddress {

--- a/crates/yttrium/src/smart_accounts/simple_account/sender_address.rs
+++ b/crates/yttrium/src/smart_accounts/simple_account/sender_address.rs
@@ -26,8 +26,7 @@ pub async fn get_sender_address_with_signer(
     let rpc_base_url = config.clone().endpoints.rpc.base_url;
 
     let chain_id = ChainId::new_eip155(chain_id);
-    let chain =
-        crate::chain::Chain::new(chain_id.clone(), EntryPointVersion::V07, "");
+    let chain = crate::chain::Chain::new(chain_id, EntryPointVersion::V07, "");
 
     let entry_point_config = chain.entry_point_config();
 

--- a/crates/yttrium/src/smart_accounts/simple_account/sender_address.rs
+++ b/crates/yttrium/src/smart_accounts/simple_account/sender_address.rs
@@ -4,8 +4,11 @@ use crate::{
     entry_point::{
         get_sender_address::get_sender_address_v07, EntryPointVersion,
     },
-    smart_accounts::simple_account::{
-        create_account::SimpleAccountCreate, factory::FactoryAddress,
+    smart_accounts::{
+        account_address::AccountAddress,
+        simple_account::{
+            create_account::SimpleAccountCreate, factory::FactoryAddress,
+        },
     },
 };
 use alloy::{
@@ -17,7 +20,7 @@ pub async fn get_sender_address_with_signer(
     config: Config,
     chain_id: u64,
     signer: PrivateKeySigner,
-) -> eyre::Result<Address> {
+) -> eyre::Result<AccountAddress> {
     let _bundler_base_url = config.clone().endpoints.bundler.base_url;
     let _paymaster_base_url = config.clone().endpoints.paymaster.base_url;
     let rpc_base_url = config.clone().endpoints.rpc.base_url;

--- a/crates/yttrium/src/transaction.rs
+++ b/crates/yttrium/src/transaction.rs
@@ -1,8 +1,9 @@
 use alloy::primitives::{address, Address, Bytes, U256};
+use serde::{Deserialize, Serialize};
 
 pub mod send;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Transaction {
     pub to: Address,
     pub value: U256,

--- a/crates/yttrium/src/transaction/send.rs
+++ b/crates/yttrium/src/transaction/send.rs
@@ -124,7 +124,7 @@ mod tests {
             nonce::get_nonce,
             simple_account::{
                 create_account::SimpleAccountCreate, factory::FactoryAddress,
-                SimpleAccountAddress, SimpleAccountExecute,
+                SimpleAccountExecute,
             },
         },
         user_operation::UserOperationV07,
@@ -261,16 +261,12 @@ mod tests {
 
         println!("Gas price: {:?}", gas_price);
 
-        let nonce = get_nonce(
-            &provider,
-            &SimpleAccountAddress::new(sender_address),
-            &entry_point_address,
-        )
-        .await?;
+        let nonce =
+            get_nonce(&provider, sender_address, &entry_point_address).await?;
 
         let user_op = UserOperationV07 {
             sender: sender_address,
-            nonce: U256::from(nonce),
+            nonce,
             factory: None,
             factory_data: None,
             call_data: Bytes::from_str(&call_data_value_hex)?,

--- a/crates/yttrium/src/transaction/send.rs
+++ b/crates/yttrium/src/transaction/send.rs
@@ -1,4 +1,3 @@
-use crate::smart_accounts::safe::Execution;
 use crate::transaction::send::simple_account_test::send_transaction_with_signer;
 use crate::{
     config::Config, transaction::Transaction, user_operation::UserOperationV07,
@@ -89,11 +88,7 @@ pub async fn send_transaction_with_private_key_signer(
 
     let user_operation_hash = if safe {
         safe_test::send_transaction(
-            vec![Execution {
-                target: transaction.to,
-                value: transaction.value,
-                callData: transaction.data,
-            }],
+            vec![transaction],
             signer,
             None,
             None,

--- a/crates/yttrium/src/transaction/send/safe_test.rs
+++ b/crates/yttrium/src/transaction/send/safe_test.rs
@@ -409,7 +409,7 @@ mod tests {
         faucet: LocalSigner<SigningKey>,
         amount: U256,
         to: Address,
-    ) -> eyre::Result<()> {
+    ) {
         // Basic check (which we can tune) to make sure we don't use excessive
         // amounts (e.g. 0.1) of test ETH. It is not infinite, so we should use
         // the minimum amount necessary.
@@ -422,13 +422,13 @@ mod tests {
             .send_transaction(
                 TransactionRequest::default().with_to(to).with_value(amount),
             )
-            .await?
+            .await
+            .unwrap()
             .watch()
-            .await?;
-        let balance = provider.get_balance(to).await?;
+            .await
+            .unwrap();
+        let balance = provider.get_balance(to).await.unwrap();
         assert_eq!(balance, amount);
-
-        Ok(())
     }
 
     async fn test_send_transaction(
@@ -456,7 +456,7 @@ mod tests {
             U256::from(2),
             sender_address.into(),
         )
-        .await?;
+        .await;
 
         let transaction = vec![Transaction {
             to: destination.address(),
@@ -558,7 +558,7 @@ mod tests {
             U256::from(3),
             sender_address.into(),
         )
-        .await?;
+        .await;
 
         let transaction = vec![];
 
@@ -607,7 +607,7 @@ mod tests {
             U256::from(3),
             sender_address.into(),
         )
-        .await?;
+        .await;
 
         let transaction = vec![
             Transaction {

--- a/crates/yttrium/src/transaction/send/send_tests/test_send_pimlico_v07.rs
+++ b/crates/yttrium/src/transaction/send/send_tests/test_send_pimlico_v07.rs
@@ -2,9 +2,12 @@
 mod tests {
     use crate::{
         bundler::{
-            client::BundlerClient, config::BundlerConfig,
-            pimlico::client::BundlerClient as PimlicoBundlerClient,
-            pimlico::paymaster::client::PaymasterClient,
+            client::BundlerClient,
+            config::BundlerConfig,
+            pimlico::{
+                client::BundlerClient as PimlicoBundlerClient,
+                paymaster::client::PaymasterClient,
+            },
         },
         entry_point::get_sender_address::get_sender_address_v07,
         smart_accounts::simple_account::{
@@ -158,16 +161,14 @@ mod tests {
 
         let nonce = crate::smart_accounts::nonce::get_nonce(
             &provider,
-            &crate::smart_accounts::simple_account::SimpleAccountAddress::new(
-                sender_address,
-            ),
+            sender_address,
             &entry_point_address,
         )
         .await?;
 
         let user_op = UserOperationV07 {
             sender: sender_address,
-            nonce: U256::from(nonce),
+            nonce,
             factory: None,
             factory_data: None,
             call_data: Bytes::from_str(&call_data_value_hex).unwrap(),

--- a/crates/yttrium/src/transaction/send/simple_account_test.rs
+++ b/crates/yttrium/src/transaction/send/simple_account_test.rs
@@ -81,8 +81,7 @@ pub async fn send_transaction_with_signer(
 
     use crate::entry_point::EntryPointVersion;
     let chain_id = ChainId::new_eip155(chain_id);
-    let chain =
-        crate::chain::Chain::new(chain_id.clone(), EntryPointVersion::V07, "");
+    let chain = crate::chain::Chain::new(chain_id, EntryPointVersion::V07, "");
     let entry_point_config = chain.entry_point_config();
 
     let entry_point_address = entry_point_config.address();

--- a/crates/yttrium/src/transaction/send/simple_account_test.rs
+++ b/crates/yttrium/src/transaction/send/simple_account_test.rs
@@ -15,7 +15,7 @@ use crate::{
         nonce::get_nonce,
         simple_account::{
             create_account::SimpleAccountCreate, factory::FactoryAddress,
-            SimpleAccountAddress, SimpleAccountExecute,
+            SimpleAccountExecute,
         },
     },
     transaction::Transaction,
@@ -169,16 +169,12 @@ pub async fn send_transaction_with_signer(
 
     println!("Gas price: {:?}", gas_price);
 
-    let nonce = get_nonce(
-        &provider,
-        &SimpleAccountAddress::new(sender_address),
-        &entry_point_address,
-    )
-    .await?;
+    let nonce =
+        get_nonce(&provider, sender_address, &entry_point_address).await?;
 
     let user_op = UserOperationV07 {
         sender: sender_address,
-        nonce: U256::from(nonce),
+        nonce,
         factory,
         factory_data,
         call_data: Bytes::from_str(&call_data_value_hex)?,
@@ -269,7 +265,7 @@ mod tests {
             nonce::get_nonce,
             simple_account::{
                 create_account::SimpleAccountCreate, factory::FactoryAddress,
-                SimpleAccountAddress, SimpleAccountExecute,
+                SimpleAccountExecute,
             },
         },
         transaction::Transaction,
@@ -372,16 +368,12 @@ mod tests {
 
         println!("Gas price: {:?}", gas_price);
 
-        let nonce = get_nonce(
-            &provider,
-            &SimpleAccountAddress::new(sender_address),
-            &entry_point_address,
-        )
-        .await?;
+        let nonce =
+            get_nonce(&provider, sender_address, &entry_point_address).await?;
 
         let user_op = UserOperationV07 {
             sender: sender_address,
-            nonce: U256::from(nonce),
+            nonce,
             factory: Some(simple_account_factory_address.to_address()),
             factory_data: Some(factory_data_value.into()),
             call_data: Bytes::from_str(&call_data_value_hex)?,

--- a/crates/yttrium/src/user_operation.rs
+++ b/crates/yttrium/src/user_operation.rs
@@ -76,7 +76,7 @@ impl UserOperationV07 {
         &self,
         entry_point: &Address,
         chain_id: u64,
-    ) -> eyre::Result<UserOperationHash> {
+    ) -> UserOperationHash {
         get_user_operation_hash_v07(self, entry_point, chain_id)
     }
 }

--- a/crates/yttrium/src/user_operation.rs
+++ b/crates/yttrium/src/user_operation.rs
@@ -1,18 +1,24 @@
-use alloy::primitives::{Address, Bytes, U256};
+use crate::{
+    smart_accounts::account_address::AccountAddress,
+    user_operation::{
+        hash::get_user_operation_hash_v07,
+        user_operation_hash::UserOperationHash,
+    },
+};
+use alloy::primitives::{address, Address, Bytes, U256};
 use serde::{Deserialize, Serialize};
 
 pub mod hash;
 pub mod user_operation_hash;
 
-use crate::user_operation::{
-    hash::get_user_operation_hash_v07, user_operation_hash::UserOperationHash,
-};
-
-pub fn as_checksum_addr<S>(val: &Address, s: S) -> Result<S::Ok, S::Error>
+pub fn as_checksum_addr<S>(
+    val: &AccountAddress,
+    s: S,
+) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
 {
-    let address_checksum: String = val.to_checksum(None);
+    let address_checksum: String = val.to_address().to_checksum(None);
     serde::Serialize::serialize(&address_checksum, s)
 }
 
@@ -51,7 +57,7 @@ pub struct Authorization {
 #[serde(rename_all = "camelCase")]
 pub struct UserOperationV07 {
     #[serde(serialize_with = "as_checksum_addr")]
-    pub sender: Address,
+    pub sender: AccountAddress,
     pub nonce: U256,
     pub factory: Option<Address>,
     pub factory_data: Option<Bytes>,
@@ -85,9 +91,8 @@ impl UserOperationV07 {
     pub fn mock() -> Self {
         use std::str::FromStr;
 
-        let sender = "0xa3aBDC7f6334CD3EE466A115f30522377787c024"
-            .parse::<Address>()
-            .unwrap();
+        let sender =
+            address!("a3aBDC7f6334CD3EE466A115f30522377787c024").into();
         let nonce = U256::from(16);
         let factory: Option<Address> = None;
         let factory_data: Option<Bytes> = None;

--- a/crates/yttrium/src/user_operation/hash.rs
+++ b/crates/yttrium/src/user_operation/hash.rs
@@ -12,9 +12,9 @@ pub fn get_user_operation_hash_v07(
     user_operation: &UserOperationV07,
     entry_point: &Address,
     chain_id: u64,
-) -> eyre::Result<UserOperationHash> {
+) -> UserOperationHash {
     let packed_user_operation = {
-        let packed = pack_v07::pack_user_operation_v07(user_operation)?;
+        let packed = pack_v07::pack_user_operation_v07(user_operation);
         println!("packed: {:?}", packed);
         keccak256(packed)
     };
@@ -32,8 +32,7 @@ pub fn get_user_operation_hash_v07(
     let encoded: Bytes = abi_encoded.into();
     let hash_bytes = keccak256(encoded);
     let hash = B256::from_slice(hash_bytes.as_slice());
-    let user_op_hash = UserOperationHash(hash);
-    Ok(user_op_hash)
+    UserOperationHash(hash)
 }
 
 #[cfg(test)]
@@ -41,24 +40,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_get_user_operation_hash_v07() -> eyre::Result<()> {
+    fn test_get_user_operation_hash_v07() {
         let expected_hash =
             "0xa1ea19d934f05fc2d725f2be8452ad7e2f29d9747674045ea366a320b782411d";
         let user_operation = UserOperationV07::mock();
-        let entry_point =
-            "0x0000000071727De22E5E9d8BAf0edAc6f37da032".parse::<Address>()?;
+        let entry_point = "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
+            .parse::<Address>()
+            .unwrap();
         let chain_id = 11155111;
         let hash = get_user_operation_hash_v07(
             &user_operation,
             &entry_point,
             chain_id,
-        )?;
-        println!("hash: {:?}", hash);
-        eyre::ensure!(
-            format!("{}", hash.0) == expected_hash,
-            "hash should be {}",
-            expected_hash
         );
-        Ok(())
+        assert_eq!(hash.0.to_string(), expected_hash);
     }
 }

--- a/crates/yttrium/src/user_operation/hash/pack_v07.rs
+++ b/crates/yttrium/src/user_operation/hash/pack_v07.rs
@@ -1,5 +1,4 @@
 use crate::user_operation::UserOperationV07;
-use alloy::primitives::Address;
 use alloy::sol_types::SolValue;
 
 pub mod combine;
@@ -27,17 +26,8 @@ pub fn pack_user_operation_v07(user_operation: &UserOperationV07) -> Vec<u8> {
     let max_priority_fee_per_gas_and_max_fee_per_gas_item =
         max_priority_fee_per_gas_and_max_fee_per_gas::get_max_priority_fee_per_gas_and_max_fee_per_gas(user_operation);
 
-    let items: (
-        Address,
-        alloy::primitives::Uint<256, 4>,
-        alloy::primitives::FixedBytes<32>,
-        alloy::primitives::FixedBytes<32>,
-        alloy::primitives::FixedBytes<32>,
-        alloy::primitives::Uint<256, 4>,
-        alloy::primitives::FixedBytes<32>,
-        alloy::primitives::FixedBytes<32>,
-    ) = (
-        user_operation.sender as Address,
+    let items = (
+        user_operation.sender.to_address(),
         user_operation.nonce,
         hashed_init_code,
         hashed_call_data,

--- a/crates/yttrium/src/user_operation/hash/pack_v07.rs
+++ b/crates/yttrium/src/user_operation/hash/pack_v07.rs
@@ -25,7 +25,7 @@ pub fn pack_user_operation_v07(user_operation: &UserOperationV07) -> Vec<u8> {
         verificaction_gas_limit_and_call_gas_limit::get_verificaction_gas_limit_and_call_gas_limit(user_operation);
 
     let max_priority_fee_per_gas_and_max_fee_per_gas_item =
-        max_priority_fee_per_gas_and_max_fee_per_gas::get_max_priority_fee_per_gas_and_max_fee_per_gas(user_operation).unwrap();
+        max_priority_fee_per_gas_and_max_fee_per_gas::get_max_priority_fee_per_gas_and_max_fee_per_gas(user_operation);
 
     let items: (
         Address,

--- a/crates/yttrium/src/user_operation/hash/pack_v07.rs
+++ b/crates/yttrium/src/user_operation/hash/pack_v07.rs
@@ -1,5 +1,6 @@
 use crate::user_operation::UserOperationV07;
 use alloy::primitives::Address;
+use alloy::sol_types::SolValue;
 
 pub mod combine;
 pub mod hashed_call_data;
@@ -8,43 +9,23 @@ pub mod hashed_paymaster_and_data;
 pub mod max_priority_fee_per_gas_and_max_fee_per_gas;
 pub mod verificaction_gas_limit_and_call_gas_limit;
 
-pub fn pack_user_operation_v07(
-    user_operation: &UserOperationV07,
-) -> eyre::Result<Vec<u8>> {
-    println!(
-        "pack_user_operation_v07 user_operation: {:?}",
-        user_operation.clone()
-    );
-
+pub fn pack_user_operation_v07(user_operation: &UserOperationV07) -> Vec<u8> {
     let hashed_init_code =
-        hashed_init_code::get_hashed_init_code(user_operation)?;
-    println!("hashed_init_code: {:?}", hashed_init_code);
+        hashed_init_code::get_hashed_init_code(user_operation);
 
     let hashed_call_data =
-        hashed_call_data::get_hashed_call_data(user_operation)?;
-    println!("hashed_call_data: {:?}", hashed_call_data);
+        hashed_call_data::get_hashed_call_data(user_operation);
 
     let hashed_paymaster_and_data =
         hashed_paymaster_and_data::get_hashed_paymaster_and_data(
             user_operation,
-        )?;
-    println!("hashed_paymaster_and_data: {:?}", hashed_paymaster_and_data);
-
-    use alloy::sol_types::SolValue;
+        );
 
     let verificaction_gas_limit_and_call_gas_limit_item =
-        verificaction_gas_limit_and_call_gas_limit::get_verificaction_gas_limit_and_call_gas_limit(user_operation)?;
-    println!(
-        "verificaction_gas_limit_and_call_gas_limit_item: {:?}",
-        verificaction_gas_limit_and_call_gas_limit_item
-    );
+        verificaction_gas_limit_and_call_gas_limit::get_verificaction_gas_limit_and_call_gas_limit(user_operation);
 
     let max_priority_fee_per_gas_and_max_fee_per_gas_item =
-        max_priority_fee_per_gas_and_max_fee_per_gas::get_max_priority_fee_per_gas_and_max_fee_per_gas(user_operation)?;
-    println!(
-        "max_priority_fee_per_gas_and_max_fee_per_gas_item: {:?}",
-        max_priority_fee_per_gas_and_max_fee_per_gas_item
-    );
+        max_priority_fee_per_gas_and_max_fee_per_gas::get_max_priority_fee_per_gas_and_max_fee_per_gas(user_operation).unwrap();
 
     let items: (
         Address,
@@ -66,10 +47,7 @@ pub fn pack_user_operation_v07(
         hashed_paymaster_and_data,
     );
 
-    let encoded = items.abi_encode();
-    println!("encoded: {:?}", encoded.clone());
-
-    Ok(encoded)
+    items.abi_encode()
 }
 
 #[cfg(test)]
@@ -77,24 +55,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_pack_user_operation_v07() -> eyre::Result<()> {
+    fn test_pack_user_operation_v07() {
         let expected_packed_user_operation_hex = "0x000000000000000000000000a3abdc7f6334cd3ee466a115f30522377787c0240000000000000000000000000000000000000000000000000000000000000010c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a4700a8139e8d993db78f1d6b8682c7dcf9d4ef0b49b8bf883dc0a22a45b7aa7da2c00000000000000000000000000010b2500000000000000000000000000013880000000000000000000000000000000000000000000000000000000000000d9a900000000000000000000000043d4ca3500000000000000000000000417bbd4f1fc0dffa735c71f138a00eaaafa56834aebf784e3e446612810f3f325cfb8eda9";
 
         let user_operation = UserOperationV07::mock();
-        let packed_user_operation = pack_user_operation_v07(&user_operation)?;
-        println!("packed_user_operation: {:?}", packed_user_operation);
+        let packed_user_operation = pack_user_operation_v07(&user_operation);
 
-        let packed_user_operation_hex =
-            hex::encode(packed_user_operation.clone());
-        println!("packed_user_operation_hex: {:?}", packed_user_operation_hex);
+        let packed_user_operation_hex = hex::encode(&packed_user_operation);
 
-        eyre::ensure!(
-            format!("0x{}", packed_user_operation_hex)
-                == expected_packed_user_operation_hex,
-            "packed_user_operation_hex should be {:?}",
-            expected_packed_user_operation_hex
+        assert_eq!(
+            format!("0x{}", packed_user_operation_hex),
+            expected_packed_user_operation_hex,
         );
-
-        Ok(())
     }
 }

--- a/crates/yttrium/src/user_operation/hash/pack_v07/combine.rs
+++ b/crates/yttrium/src/user_operation/hash/pack_v07/combine.rs
@@ -1,41 +1,25 @@
-use alloy::primitives::{Uint, B256};
-use std::str::FromStr;
+use alloy::primitives::{B256, U256};
 
-pub fn combine_and_trim_first_16_bytes(
-    items: Vec<Uint<256, 4>>,
-) -> eyre::Result<B256> {
-    let items_bytes_hex = items
-        .iter()
-        .map(|item| item.to_be_bytes_vec()[16..].to_vec())
-        .map(hex::encode)
-        .collect::<Vec<String>>();
-    println!("items_bytes_hex: {:?}", items_bytes_hex);
-
-    let combined = items_bytes_hex.join("");
-    println!("combined: {:?}", combined);
-
-    let result = B256::from_str(&combined)?;
-
-    Ok(result)
+pub fn combine_and_trim_first_16_bytes(item1: U256, item2: U256) -> B256 {
+    let mut vec = Vec::with_capacity(32);
+    vec.extend_from_slice(&item1.to_be_bytes_vec()[16..]);
+    vec.extend_from_slice(&item2.to_be_bytes_vec()[16..]);
+    B256::from_slice(&vec)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy::primitives::b256;
 
     #[test]
-    fn test_combine_and_trim_first_16_bytes() -> eyre::Result<()> {
-        let expected_result = B256::from_str(
-            "0000000000000000000000000000000100000000000000000000000000000002",
-        )?;
-        let items = vec![Uint::<256, 4>::from(1), Uint::<256, 4>::from(2)];
-        let result = combine_and_trim_first_16_bytes(items)?;
-        println!("result: {:?}", result);
-        eyre::ensure!(
-            result == expected_result,
-            "result should be {}",
-            expected_result
+    fn test_combine_and_trim_first_16_bytes() {
+        let expected_result = b256!(
+            "0000000000000000000000000000000100000000000000000000000000000002"
         );
-        Ok(())
+        let item1 = U256::from(1);
+        let item2 = U256::from(2);
+        let result = combine_and_trim_first_16_bytes(item1, item2);
+        assert_eq!(result, expected_result);
     }
 }

--- a/crates/yttrium/src/user_operation/hash/pack_v07/hashed_call_data.rs
+++ b/crates/yttrium/src/user_operation/hash/pack_v07/hashed_call_data.rs
@@ -1,16 +1,8 @@
 use crate::user_operation::UserOperationV07;
 use alloy::primitives::{keccak256, B256};
 
-pub fn get_hashed_call_data(
-    user_operation: &UserOperationV07,
-) -> eyre::Result<B256> {
-    let hashed_call_data = {
-        let call_data = user_operation.clone().call_data;
-        keccak256(call_data)
-    };
-    let hashed_call_data_hex = hex::encode(hashed_call_data);
-    println!("hashed_call_data_hex: {:?}", hashed_call_data_hex);
-    Ok(hashed_call_data)
+pub fn get_hashed_call_data(user_operation: &UserOperationV07) -> B256 {
+    keccak256(&user_operation.call_data)
 }
 
 #[cfg(test)]
@@ -18,17 +10,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_get_hashed_call_data() -> eyre::Result<()> {
+    fn test_get_hashed_call_data() {
         let expected_hashed_call_data_hex =
             "0x0a8139e8d993db78f1d6b8682c7dcf9d4ef0b49b8bf883dc0a22a45b7aa7da2c";
         let user_operation = UserOperationV07::mock();
-        let hashed_call_data = get_hashed_call_data(&user_operation)?;
-        println!("hashed_call_data: {:?}", hashed_call_data);
-        eyre::ensure!(
-            format!("{}", hashed_call_data) == expected_hashed_call_data_hex,
-            "hashed_call_data should be {}",
-            expected_hashed_call_data_hex
-        );
-        Ok(())
+        let hashed_call_data = get_hashed_call_data(&user_operation);
+        assert_eq!(hashed_call_data.to_string(), expected_hashed_call_data_hex,);
     }
 }

--- a/crates/yttrium/src/user_operation/hash/pack_v07/hashed_init_code.rs
+++ b/crates/yttrium/src/user_operation/hash/pack_v07/hashed_init_code.rs
@@ -1,9 +1,7 @@
 use crate::user_operation::UserOperationV07;
 use alloy::primitives::{keccak256, B256};
 
-pub fn get_hashed_init_code(
-    user_operation: &UserOperationV07,
-) -> eyre::Result<B256> {
+pub fn get_hashed_init_code(user_operation: &UserOperationV07) -> B256 {
     let uo = user_operation.clone();
     let value_vec = if let (Some(factory), Some(factory_data)) =
         (uo.factory, uo.factory_data.clone())
@@ -19,10 +17,7 @@ pub fn get_hashed_init_code(
         bytes_vec
     };
 
-    let hashed_init_code = keccak256(value_vec);
-    println!("hashed_init_code: {:?}", hashed_init_code);
-
-    Ok(hashed_init_code)
+    keccak256(value_vec)
 }
 
 #[cfg(test)]
@@ -30,17 +25,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_get_hashed_init_code() -> eyre::Result<()> {
+    fn test_get_hashed_init_code() {
         let expected_hashed_init_code_hex =
             "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470";
         let user_operation = UserOperationV07::mock();
-        let hashed_init_code = get_hashed_init_code(&user_operation)?;
-        println!("hashed_init_code: {:?}", hashed_init_code);
-        eyre::ensure!(
-            format!("{}", hashed_init_code) == expected_hashed_init_code_hex,
-            "hashed_init_code should be {}",
-            expected_hashed_init_code_hex
-        );
-        Ok(())
+        let hashed_init_code = get_hashed_init_code(&user_operation);
+        assert_eq!(hashed_init_code.to_string(), expected_hashed_init_code_hex);
     }
 }

--- a/crates/yttrium/src/user_operation/hash/pack_v07/hashed_paymaster_and_data.rs
+++ b/crates/yttrium/src/user_operation/hash/pack_v07/hashed_paymaster_and_data.rs
@@ -1,70 +1,46 @@
 use crate::user_operation::UserOperationV07;
-use alloy::primitives::{keccak256, Bytes, Uint, B256, U256};
-use std::str::FromStr;
+use alloy::primitives::{keccak256, Bytes, B256};
 
-fn trim_first_16_bytes_or_default(item: Option<Uint<256, 4>>) -> String {
-    let item = item.unwrap_or(U256::from(0));
+fn get_data(user_operation: &UserOperationV07) -> Bytes {
+    if let Some(paymaster) = user_operation.paymaster {
+        let address = paymaster.into_iter();
 
-    let item_bytes_vec: Vec<u8> = item.to_be_bytes_vec()[16..].to_vec();
+        let paymaster_verification_gas_limit = user_operation
+            .paymaster_verification_gas_limit
+            .unwrap_or_default()
+            .to_be_bytes_vec()
+            .into_iter()
+            .skip(16);
 
-    hex::encode(item_bytes_vec)
-}
+        let paymaster_post_op_gas_limit = user_operation
+            .paymaster_post_op_gas_limit
+            .unwrap_or_default()
+            .to_be_bytes_vec()
+            .into_iter()
+            .skip(16);
 
-fn get_data(user_operation: &UserOperationV07) -> eyre::Result<Bytes> {
-    let uo: UserOperationV07 = user_operation.clone();
+        let paymaster_data = user_operation
+            .paymaster_data
+            .as_ref()
+            .unwrap_or_default()
+            .iter()
+            .copied();
 
-    let data = if let Some(paymaster) = uo.paymaster {
-        println!("paymaster: {:?}", paymaster);
-
-        let paymaster_hex = format!("{}", paymaster);
-
-        let paymaster_verification_gas_limit_hex =
-            trim_first_16_bytes_or_default(uo.paymaster_verification_gas_limit);
-
-        let paymaster_post_op_gas_limit_hex =
-            trim_first_16_bytes_or_default(uo.paymaster_post_op_gas_limit);
-
-        let paymaster_data = {
-            let paymaster_data = uo.paymaster_data.clone().unwrap_or_default();
-
-            let paymaster_data_hex =
-                format!("{:?}", paymaster_data)[2..].to_string();
-            println!("paymaster_data_hex: {:?}", paymaster_data_hex);
-
-            paymaster_data_hex
-        };
-
-        let combined = format!(
-            "{}{}{}{}",
-            paymaster_hex,
-            paymaster_verification_gas_limit_hex,
-            paymaster_post_op_gas_limit_hex,
-            paymaster_data
-        );
-        println!("combined: {:?}", combined);
-
-        combined
+        address
+            .chain(paymaster_verification_gas_limit)
+            .chain(paymaster_post_op_gas_limit)
+            .chain(paymaster_data)
+            .collect()
     } else {
-        "".to_string()
-    };
-
-    let data = data.strip_prefix("0x").unwrap();
-
-    let bytes = Bytes::from_str(data)?;
-
-    Ok(bytes)
+        Bytes::new()
+    }
 }
 
 pub fn get_hashed_paymaster_and_data(
     user_operation: &UserOperationV07,
-) -> eyre::Result<B256> {
-    let data = get_data(user_operation)?;
-    println!("data: {:?}", data);
-
-    let hashed = keccak256(data);
-    println!("hashed: {:?}", hashed);
-
-    Ok(hashed)
+) -> B256 {
+    let data = get_data(user_operation);
+    keccak256(data)
 }
 
 #[cfg(test)]
@@ -72,18 +48,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_get_hashed_paymaster_and_data() -> eyre::Result<()> {
+    fn test_get_hashed_paymaster_and_data() {
         let expected_hashed_paymaster_and_data_hex = "0xfc0dffa735c71f138a00eaaafa56834aebf784e3e446612810f3f325cfb8eda9";
         let user_operation = UserOperationV07::mock();
         let hashed_paymaster_and_data =
-            get_hashed_paymaster_and_data(&user_operation)?;
-        println!("hashed_paymaster_and_data: {:?}", hashed_paymaster_and_data);
-        eyre::ensure!(
-            format!("{}", hashed_paymaster_and_data)
-                == expected_hashed_paymaster_and_data_hex,
-            "hashed_paymaster_and_data should be {}",
-            expected_hashed_paymaster_and_data_hex
+            get_hashed_paymaster_and_data(&user_operation);
+        assert_eq!(
+            hashed_paymaster_and_data.to_string(),
+            expected_hashed_paymaster_and_data_hex,
         );
-        Ok(())
     }
 }

--- a/crates/yttrium/src/user_operation/hash/pack_v07/max_priority_fee_per_gas_and_max_fee_per_gas.rs
+++ b/crates/yttrium/src/user_operation/hash/pack_v07/max_priority_fee_per_gas_and_max_fee_per_gas.rs
@@ -3,36 +3,29 @@ use alloy::primitives::B256;
 
 pub fn get_max_priority_fee_per_gas_and_max_fee_per_gas(
     user_operation: &UserOperationV07,
-) -> eyre::Result<B256> {
-    let values = vec![
+) -> B256 {
+    super::combine::combine_and_trim_first_16_bytes(
         user_operation.max_priority_fee_per_gas,
         user_operation.max_fee_per_gas,
-    ];
-    let combined = super::combine::combine_and_trim_first_16_bytes(values)?;
-    Ok(combined)
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy::primitives::fixed_bytes;
 
     #[test]
-    fn test_get_max_priority_fee_per_gas_and_max_fee_per_gas(
-    ) -> eyre::Result<()> {
-        let expected_max_priority_fee_per_gas_and_max_fee_per_gas_hex = "0x00000000000000000000000043d4ca3500000000000000000000000417bbd4f1";
+    fn test_get_max_priority_fee_per_gas_and_max_fee_per_gas() {
+        let expected_max_priority_fee_per_gas_and_max_fee_per_gas = fixed_bytes!(
+            "00000000000000000000000043d4ca3500000000000000000000000417bbd4f1"
+        );
         let user_operation = UserOperationV07::mock();
         let max_priority_fee_per_gas_and_max_fee_per_gas =
-            get_max_priority_fee_per_gas_and_max_fee_per_gas(&user_operation)?;
-        println!(
-            "max_priority_fee_per_gas_and_max_fee_per_gas: {:?}",
-            max_priority_fee_per_gas_and_max_fee_per_gas
+            get_max_priority_fee_per_gas_and_max_fee_per_gas(&user_operation);
+        assert_eq!(
+            max_priority_fee_per_gas_and_max_fee_per_gas,
+            expected_max_priority_fee_per_gas_and_max_fee_per_gas,
         );
-        eyre::ensure!(
-            format!("{}", max_priority_fee_per_gas_and_max_fee_per_gas)
-                == expected_max_priority_fee_per_gas_and_max_fee_per_gas_hex,
-            "max_priority_fee_per_gas_and_max_fee_per_gas should be {}",
-            expected_max_priority_fee_per_gas_and_max_fee_per_gas_hex
-        );
-        Ok(())
     }
 }

--- a/crates/yttrium/src/user_operation/hash/pack_v07/verificaction_gas_limit_and_call_gas_limit.rs
+++ b/crates/yttrium/src/user_operation/hash/pack_v07/verificaction_gas_limit_and_call_gas_limit.rs
@@ -4,13 +4,12 @@ use alloy::primitives::B256;
 
 pub fn get_verificaction_gas_limit_and_call_gas_limit(
     user_operation: &UserOperationV07,
-) -> eyre::Result<B256> {
+) -> B256 {
     let values = vec![
         user_operation.verification_gas_limit,
         user_operation.call_gas_limit,
     ];
-    let combined = combine_and_trim_first_16_bytes(values)?;
-    Ok(combined)
+    combine_and_trim_first_16_bytes(values).unwrap()
 }
 
 #[cfg(test)]
@@ -18,23 +17,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_get_verificaction_gas_limit_and_call_gas_limit() -> eyre::Result<()>
-    {
+    fn test_get_verificaction_gas_limit_and_call_gas_limit() {
         let expected_verification_gas_limit_and_call_gas_limit_hex =
             "0x00000000000000000000000000010b2500000000000000000000000000013880";
         let user_operation = UserOperationV07::mock();
         let verification_gas_limit_and_call_gas_limit =
-            get_verificaction_gas_limit_and_call_gas_limit(&user_operation)?;
-        println!(
-            "verification_gas_limit_and_call_gas_limit: {:?}",
-            verification_gas_limit_and_call_gas_limit
+            get_verificaction_gas_limit_and_call_gas_limit(&user_operation);
+        assert_eq!(
+            verification_gas_limit_and_call_gas_limit.to_string(),
+            expected_verification_gas_limit_and_call_gas_limit_hex,
         );
-        eyre::ensure!(
-            format!("{}", verification_gas_limit_and_call_gas_limit)
-                == expected_verification_gas_limit_and_call_gas_limit_hex,
-            "verification_gas_limit_and_call_gas_limit should be {}",
-            expected_verification_gas_limit_and_call_gas_limit_hex
-        );
-        Ok(())
     }
 }

--- a/crates/yttrium/src/user_operation/hash/pack_v07/verificaction_gas_limit_and_call_gas_limit.rs
+++ b/crates/yttrium/src/user_operation/hash/pack_v07/verificaction_gas_limit_and_call_gas_limit.rs
@@ -5,27 +5,28 @@ use alloy::primitives::B256;
 pub fn get_verificaction_gas_limit_and_call_gas_limit(
     user_operation: &UserOperationV07,
 ) -> B256 {
-    let values = vec![
+    combine_and_trim_first_16_bytes(
         user_operation.verification_gas_limit,
         user_operation.call_gas_limit,
-    ];
-    combine_and_trim_first_16_bytes(values).unwrap()
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy::primitives::fixed_bytes;
 
     #[test]
     fn test_get_verificaction_gas_limit_and_call_gas_limit() {
-        let expected_verification_gas_limit_and_call_gas_limit_hex =
-            "0x00000000000000000000000000010b2500000000000000000000000000013880";
+        let expected_verification_gas_limit_and_call_gas_limit = fixed_bytes!(
+            "00000000000000000000000000010b2500000000000000000000000000013880"
+        );
         let user_operation = UserOperationV07::mock();
         let verification_gas_limit_and_call_gas_limit =
             get_verificaction_gas_limit_and_call_gas_limit(&user_operation);
         assert_eq!(
-            verification_gas_limit_and_call_gas_limit.to_string(),
-            expected_verification_gas_limit_and_call_gas_limit_hex,
+            verification_gas_limit_and_call_gas_limit,
+            expected_verification_gas_limit_and_call_gas_limit,
         );
     }
 }


### PR DESCRIPTION
- Refactor code to remove unnecessary Result return types and unwraps()
- Extract get_call_data function from test code
- Make ABI building build script closer to only running when necessary
- Refactor use of `Address` to `AccountAddress` so we are more explicit about addresses that are accounts
- Fix that `pimlico_getUserOperationGasPrice` client didn't send `params`. While it seems like Pimlico didn't care, their docs have this, and Blockchain API's bundler proxy validation requires it.
- Add smart sessions Solidity bindings
- Add LICENSE