### PR TITLE
feat: ERC-6492 signature verification

### DIFF
--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -37,6 +37,7 @@ reqwest.workspace = true
 
 # Logging
 log.workspace = true
+url = "2.5.2"
 
 [target.'cfg(target_os = "ios")'.dependencies]
 oslog.workspace = true

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -19,6 +19,8 @@ swift-bridge = { git = "https://github.com/wooden-worm/swift-bridge.git", branch
     "async",
 ] }
 yttrium = { path = "../yttrium" }
+erc6492 = { git = "https://github.com/reown-com/erc6492.git" }
+alloy = { version = "0.3.6" }
 
 # Errors
 eyre.workspace = true

--- a/crates/ffi/YttriumCore/Sources/YttriumCore/SwiftFFI/Error/Erc6492.swift
+++ b/crates/ffi/YttriumCore/Sources/YttriumCore/SwiftFFI/Error/Erc6492.swift
@@ -1,0 +1,4 @@
+import Foundation
+
+extension Erc6492Error: @unchecked Sendable {}
+extension Erc6492Error: Error {}

--- a/crates/ffi/YttriumCore/Sources/YttriumCore/ffi.swift
+++ b/crates/ffi/YttriumCore/Sources/YttriumCore/ffi.swift
@@ -715,5 +715,165 @@ public func __swift_bridge__PrivateKeySignerFFI__free (ptr: UnsafeMutableRawPoin
     let _ = Unmanaged<PrivateKeySignerFFI>.fromOpaque(ptr).takeRetainedValue()
 }
 
+public enum Erc6492Error {
+    case InvalidSignature(RustString)
+    case InvalidAddress(RustString)
+    case InvalidMessageHash(RustString)
+    case Verification(RustString)
+}
+extension Erc6492Error {
+    func intoFfiRepr() -> __swift_bridge__$Erc6492Error {
+        switch self {
+            case Erc6492Error.InvalidSignature(let _0):
+                return __swift_bridge__$Erc6492Error(tag: __swift_bridge__$Erc6492Error$InvalidSignature, payload: __swift_bridge__$Erc6492ErrorFields(InvalidSignature: __swift_bridge__$Erc6492Error$FieldOfInvalidSignature(_0: { let rustString = _0.intoRustString(); rustString.isOwned = false; return rustString.ptr }())))
+            case Erc6492Error.InvalidAddress(let _0):
+                return __swift_bridge__$Erc6492Error(tag: __swift_bridge__$Erc6492Error$InvalidAddress, payload: __swift_bridge__$Erc6492ErrorFields(InvalidAddress: __swift_bridge__$Erc6492Error$FieldOfInvalidAddress(_0: { let rustString = _0.intoRustString(); rustString.isOwned = false; return rustString.ptr }())))
+            case Erc6492Error.InvalidMessageHash(let _0):
+                return __swift_bridge__$Erc6492Error(tag: __swift_bridge__$Erc6492Error$InvalidMessageHash, payload: __swift_bridge__$Erc6492ErrorFields(InvalidMessageHash: __swift_bridge__$Erc6492Error$FieldOfInvalidMessageHash(_0: { let rustString = _0.intoRustString(); rustString.isOwned = false; return rustString.ptr }())))
+            case Erc6492Error.Verification(let _0):
+                return __swift_bridge__$Erc6492Error(tag: __swift_bridge__$Erc6492Error$Verification, payload: __swift_bridge__$Erc6492ErrorFields(Verification: __swift_bridge__$Erc6492Error$FieldOfVerification(_0: { let rustString = _0.intoRustString(); rustString.isOwned = false; return rustString.ptr }())))
+        }
+    }
+}
+extension __swift_bridge__$Erc6492Error {
+    func intoSwiftRepr() -> Erc6492Error {
+        switch self.tag {
+            case __swift_bridge__$Erc6492Error$InvalidSignature:
+                return Erc6492Error.InvalidSignature(RustString(ptr: self.payload.InvalidSignature._0))
+            case __swift_bridge__$Erc6492Error$InvalidAddress:
+                return Erc6492Error.InvalidAddress(RustString(ptr: self.payload.InvalidAddress._0))
+            case __swift_bridge__$Erc6492Error$InvalidMessageHash:
+                return Erc6492Error.InvalidMessageHash(RustString(ptr: self.payload.InvalidMessageHash._0))
+            case __swift_bridge__$Erc6492Error$Verification:
+                return Erc6492Error.Verification(RustString(ptr: self.payload.Verification._0))
+            default:
+                fatalError("Unreachable")
+        }
+    }
+}
+extension __swift_bridge__$Option$Erc6492Error {
+    @inline(__always)
+    func intoSwiftRepr() -> Optional<Erc6492Error> {
+        if self.is_some {
+            return self.val.intoSwiftRepr()
+        } else {
+            return nil
+        }
+    }
+    @inline(__always)
+    static func fromSwiftRepr(_ val: Optional<Erc6492Error>) -> __swift_bridge__$Option$Erc6492Error {
+        if let v = val {
+            return __swift_bridge__$Option$Erc6492Error(is_some: true, val: v.intoFfiRepr())
+        } else {
+            return __swift_bridge__$Option$Erc6492Error(is_some: false, val: __swift_bridge__$Erc6492Error())
+        }
+    }
+}
+
+public class Erc6492Client: Erc6492ClientRefMut {
+    var isOwned: Bool = true
+
+    public override init(ptr: UnsafeMutableRawPointer) {
+        super.init(ptr: ptr)
+    }
+
+    deinit {
+        if isOwned {
+            __swift_bridge__$Erc6492Client$_free(ptr)
+        }
+    }
+}
+extension Erc6492Client {
+    public convenience init<GenericIntoRustString: IntoRustString>(_ rpc_url: GenericIntoRustString) {
+        self.init(ptr: __swift_bridge__$Erc6492Client$new({ let rustString = rpc_url.intoRustString(); rustString.isOwned = false; return rustString.ptr }()))
+    }
+}
+public class Erc6492ClientRefMut: Erc6492ClientRef {
+    public override init(ptr: UnsafeMutableRawPointer) {
+        super.init(ptr: ptr)
+    }
+}
+public class Erc6492ClientRef {
+    var ptr: UnsafeMutableRawPointer
+
+    public init(ptr: UnsafeMutableRawPointer) {
+        self.ptr = ptr
+    }
+}
+extension Erc6492ClientRef {
+    public func verify_signature<GenericIntoRustString: IntoRustString>(_ signature: GenericIntoRustString, _ address: GenericIntoRustString, _ message_hash: GenericIntoRustString) async throws -> Bool {
+        func onComplete(cbWrapperPtr: UnsafeMutableRawPointer?, rustFnRetVal: __swift_bridge__$ResultBoolAndErc6492Error) {
+            let wrapper = Unmanaged<CbWrapper$Erc6492Client$verify_signature>.fromOpaque(cbWrapperPtr!).takeRetainedValue()
+            switch rustFnRetVal.tag { case __swift_bridge__$ResultBoolAndErc6492Error$ResultOk: wrapper.cb(.success(rustFnRetVal.payload.ok)) case __swift_bridge__$ResultBoolAndErc6492Error$ResultErr: wrapper.cb(.failure(rustFnRetVal.payload.err.intoSwiftRepr())) default: fatalError() }
+        }
+
+        return try await withCheckedThrowingContinuation({ (continuation: CheckedContinuation<Bool, Error>) in
+            let callback = { rustFnRetVal in
+                continuation.resume(with: rustFnRetVal)
+            }
+
+            let wrapper = CbWrapper$Erc6492Client$verify_signature(cb: callback)
+            let wrapperPtr = Unmanaged.passRetained(wrapper).toOpaque()
+
+            __swift_bridge__$Erc6492Client$verify_signature(wrapperPtr, onComplete, ptr, { let rustString = signature.intoRustString(); rustString.isOwned = false; return rustString.ptr }(), { let rustString = address.intoRustString(); rustString.isOwned = false; return rustString.ptr }(), { let rustString = message_hash.intoRustString(); rustString.isOwned = false; return rustString.ptr }())
+        })
+    }
+    class CbWrapper$Erc6492Client$verify_signature {
+        var cb: (Result<Bool, Error>) -> ()
+    
+        public init(cb: @escaping (Result<Bool, Error>) -> ()) {
+            self.cb = cb
+        }
+    }
+}
+extension Erc6492Client: Vectorizable {
+    public static func vecOfSelfNew() -> UnsafeMutableRawPointer {
+        __swift_bridge__$Vec_Erc6492Client$new()
+    }
+
+    public static func vecOfSelfFree(vecPtr: UnsafeMutableRawPointer) {
+        __swift_bridge__$Vec_Erc6492Client$drop(vecPtr)
+    }
+
+    public static func vecOfSelfPush(vecPtr: UnsafeMutableRawPointer, value: Erc6492Client) {
+        __swift_bridge__$Vec_Erc6492Client$push(vecPtr, {value.isOwned = false; return value.ptr;}())
+    }
+
+    public static func vecOfSelfPop(vecPtr: UnsafeMutableRawPointer) -> Optional<Self> {
+        let pointer = __swift_bridge__$Vec_Erc6492Client$pop(vecPtr)
+        if pointer == nil {
+            return nil
+        } else {
+            return (Erc6492Client(ptr: pointer!) as! Self)
+        }
+    }
+
+    public static func vecOfSelfGet(vecPtr: UnsafeMutableRawPointer, index: UInt) -> Optional<Erc6492ClientRef> {
+        let pointer = __swift_bridge__$Vec_Erc6492Client$get(vecPtr, index)
+        if pointer == nil {
+            return nil
+        } else {
+            return Erc6492ClientRef(ptr: pointer!)
+        }
+    }
+
+    public static func vecOfSelfGetMut(vecPtr: UnsafeMutableRawPointer, index: UInt) -> Optional<Erc6492ClientRefMut> {
+        let pointer = __swift_bridge__$Vec_Erc6492Client$get_mut(vecPtr, index)
+        if pointer == nil {
+            return nil
+        } else {
+            return Erc6492ClientRefMut(ptr: pointer!)
+        }
+    }
+
+    public static func vecOfSelfAsPtr(vecPtr: UnsafeMutableRawPointer) -> UnsafePointer<Erc6492ClientRef> {
+        UnsafePointer<Erc6492ClientRef>(OpaquePointer(__swift_bridge__$Vec_Erc6492Client$as_ptr(vecPtr)))
+    }
+
+    public static func vecOfSelfLen(vecPtr: UnsafeMutableRawPointer) -> UInt {
+        __swift_bridge__$Vec_Erc6492Client$len(vecPtr)
+    }
+}
+
 
 

--- a/crates/ffi/src/account_client.rs
+++ b/crates/ffi/src/account_client.rs
@@ -1,8 +1,6 @@
 use super::ffi;
 use super::ffi::{FFIAccountClientConfig, FFIError};
 use crate::ffi::{FFIOwnerSignature, FFIPreparedSendTransaction};
-use alloy::network::Ethereum;
-use alloy::providers::ReqwestProvider;
 use yttrium::transaction::send::safe_test::{
     Address, OwnerSignature, Signature,
 };
@@ -247,26 +245,6 @@ impl FFIAccountClient {
             .map(serde_json::to_string)
             .collect::<Result<String, serde_json::Error>>()
             .map_err(|e| FFIError::Unknown(e.to_string()))
-    }
-
-    pub async fn verify_signature(
-        &self,
-        signature: String,
-        address: String,
-        message: String,
-    ) -> Result<bool, FFIError> {
-        let provider = ReqwestProvider::<Ethereum>::new_http(
-            self.account_client.config.endpoints.rpc.base_url.parse().map_err(
-                |e| FFIError::Unknown(format!("Parse RPC URL: {e}")),
-            )?,
-        );
-        let address = address
-            .parse::<Address>()
-            .map_err(|e| FFIError::Unknown(format!("Parse address: {e}")))?;
-        Ok(erc6492::verify_signature(signature, address, message, provider)
-            .await
-            .map_err(|e| FFIError::Unknown(e.to_string()))?
-            .is_valid())
     }
 }
 

--- a/crates/ffi/src/account_client.rs
+++ b/crates/ffi/src/account_client.rs
@@ -1,6 +1,8 @@
 use super::ffi;
 use super::ffi::{FFIAccountClientConfig, FFIError};
 use crate::ffi::{FFIOwnerSignature, FFIPreparedSendTransaction};
+use alloy::network::Ethereum;
+use alloy::providers::ReqwestProvider;
 use yttrium::transaction::send::safe_test::{
     Address, OwnerSignature, Signature,
 };
@@ -245,6 +247,26 @@ impl FFIAccountClient {
             .map(serde_json::to_string)
             .collect::<Result<String, serde_json::Error>>()
             .map_err(|e| FFIError::Unknown(e.to_string()))
+    }
+
+    pub async fn verify_signature(
+        &self,
+        signature: String,
+        address: String,
+        message: String,
+    ) -> Result<bool, FFIError> {
+        let provider = ReqwestProvider::<Ethereum>::new_http(
+            self.account_client.config.endpoints.rpc.base_url.parse().map_err(
+                |e| FFIError::Unknown(format!("Parse RPC URL: {e}")),
+            )?,
+        );
+        let address = address
+            .parse::<Address>()
+            .map_err(|e| FFIError::Unknown(format!("Parse address: {e}")))?;
+        Ok(erc6492::verify_signature(signature, address, message, provider)
+            .await
+            .map_err(|e| FFIError::Unknown(e.to_string()))?
+            .is_valid())
     }
 }
 

--- a/crates/ffi/src/erc6492_client.rs
+++ b/crates/ffi/src/erc6492_client.rs
@@ -1,0 +1,38 @@
+use crate::ffi::Erc6492Error;
+use alloy::{
+    network::Ethereum, primitives::Address, providers::ReqwestProvider,
+};
+
+pub struct Erc6492Client {
+    provider: ReqwestProvider<Ethereum>,
+}
+
+impl Erc6492Client {
+    pub fn new(rpc_url: String) -> Self {
+        let url = rpc_url.parse().expect("Invalid RPC URL");
+        let provider = ReqwestProvider::<Ethereum>::new_http(url);
+        Self { provider }
+    }
+
+    pub async fn verify_signature(
+        &self,
+        signature: String,
+        address: String,
+        message: String,
+    ) -> Result<bool, Erc6492Error> {
+        let address = address
+            .parse::<Address>()
+            .map_err(|e| Erc6492Error::InvalidAddress(e.to_string()))?;
+
+        let verification = erc6492::verify_signature(
+            signature,
+            address,
+            message,
+            &self.provider,
+        )
+        .await
+        .map_err(|e| Erc6492Error::Verification(e.to_string()))?;
+
+        Ok(verification.is_valid())
+    }
+}

--- a/crates/ffi/src/erc6492_client.rs
+++ b/crates/ffi/src/erc6492_client.rs
@@ -1,6 +1,8 @@
 use crate::ffi::Erc6492Error;
 use alloy::{
-    network::Ethereum, primitives::Address, providers::ReqwestProvider,
+    network::Ethereum,
+    primitives::{Address, Bytes, B256},
+    providers::ReqwestProvider,
 };
 
 pub struct Erc6492Client {
@@ -18,16 +20,22 @@ impl Erc6492Client {
         &self,
         signature: String,
         address: String,
-        message: String,
+        message_hash: String,
     ) -> Result<bool, Erc6492Error> {
+        let signature = signature
+            .parse::<Bytes>()
+            .map_err(|e| Erc6492Error::InvalidAddress(e.to_string()))?;
         let address = address
             .parse::<Address>()
+            .map_err(|e| Erc6492Error::InvalidAddress(e.to_string()))?;
+        let message_hash = message_hash
+            .parse::<B256>()
             .map_err(|e| Erc6492Error::InvalidAddress(e.to_string()))?;
 
         let verification = erc6492::verify_signature(
             signature,
             address,
-            message,
+            message_hash,
             &self.provider,
         )
         .await

--- a/crates/ffi/src/erc6492_client.rs
+++ b/crates/ffi/src/erc6492_client.rs
@@ -24,13 +24,13 @@ impl Erc6492Client {
     ) -> Result<bool, Erc6492Error> {
         let signature = signature
             .parse::<Bytes>()
-            .map_err(|e| Erc6492Error::InvalidAddress(e.to_string()))?;
+            .map_err(|e| Erc6492Error::InvalidSignature(e.to_string()))?;
         let address = address
             .parse::<Address>()
             .map_err(|e| Erc6492Error::InvalidAddress(e.to_string()))?;
         let message_hash = message_hash
             .parse::<B256>()
-            .map_err(|e| Erc6492Error::InvalidAddress(e.to_string()))?;
+            .map_err(|e| Erc6492Error::InvalidMessageHash(e.to_string()))?;
 
         let verification = erc6492::verify_signature(
             signature,

--- a/crates/ffi/src/error.rs
+++ b/crates/ffi/src/error.rs
@@ -1,5 +1,4 @@
-use super::ffi;
-use ffi::FFIError;
+use crate::ffi::FFIError;
 
 impl std::fmt::Display for FFIError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -145,7 +145,9 @@ mod ffi {
     }
 
     enum Erc6492Error {
+        InvalidSignature(String),
         InvalidAddress(String),
+        InvalidMessageHash(String),
         Verification(String),
     }
 

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -111,6 +111,13 @@ mod ffi {
             &self,
             user_operation_hash: String,
         ) -> Result<String, FFIError>;
+
+        pub async fn verify_signature(
+            &self,
+            signature: String,
+            address: String,
+            message: String,
+        ) -> Result<bool, FFIError>;
     }
 
     extern "Rust" {

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -161,7 +161,7 @@ mod ffi {
             &self,
             signature: String,
             address: String,
-            message: String,
+            message_hash: String,
         ) -> Result<bool, Erc6492Error>;
     }
 }

--- a/crates/yttrium/src/account_client.rs
+++ b/crates/yttrium/src/account_client.rs
@@ -56,7 +56,7 @@ impl Signer {
 pub struct AccountClient {
     owner: String,
     chain_id: u64,
-    config: Config,
+    pub config: Config,
     signer: Signer,
     safe: bool,
 }

--- a/crates/yttrium/src/transaction/send/safe_test.rs
+++ b/crates/yttrium/src/transaction/send/safe_test.rs
@@ -718,7 +718,6 @@ mod tests {
     #[tokio::test]
     async fn test_send_transaction_just_deploy() -> eyre::Result<()> {
         let config = Config::local();
-        let faucet = anvil_faucet(config.clone()).await;
 
         let provider = ReqwestProvider::<Ethereum>::new_http(
             config.endpoints.rpc.base_url.parse()?,
@@ -735,14 +734,6 @@ mod tests {
             .await
             .unwrap()
             .is_empty());
-
-        use_faucet(
-            provider.clone(),
-            faucet.clone(),
-            U256::from(3),
-            sender_address.into(),
-        )
-        .await;
 
         let transaction = vec![];
 

--- a/justfile
+++ b/justfile
@@ -7,7 +7,10 @@ clean:
 setup:
   git submodule update --init --recursive
 
-devloop: setup clippy test fmt udeps
+devloop: setup clippy fmt test udeps
+  @echo ""
+  @echo ""
+  @echo "PASS"
 
 test:
   cargo test --features=full --lib --bins

--- a/test/scripts/forked_state/docker-compose.yaml
+++ b/test/scripts/forked_state/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     restart: unless-stopped
     ports: ["8545:8545"]
     entrypoint: [ "anvil", "--fork-url", "https://gateway.tenderly.co/public/sepolia", "--host", "0.0.0.0", "--block-time", "0.1", "--gas-price", "1", "--silent", "--hardfork", "prague" ]
-    platform: linux/amd64/v8
+    platform: linux/amd64
  
   mock-paymaster:
     # image: ghcr.io/pimlicolabs/mock-verifying-paymaster:main


### PR DESCRIPTION
Adds ERC-6492 signature verification to the Swift FFI bindings

Resolves RES-93

- [x] Switch verification to be more generic to any signature, not just `personal_sign`

Depends on https://github.com/reown-com/erc6492/pull/3