### PR TITLE
fix: null user op receipt error

### DIFF
--- a/crates/kotlin-ffi/Cargo.toml
+++ b/crates/kotlin-ffi/Cargo.toml
@@ -8,7 +8,7 @@ name = "uniffi_yttrium"
 crate-type = ["cdylib"]
 
 [build-dependencies]
-uniffi_build = "0.28.1" 
+uniffi_build = "0.28.1"
 
 [dependencies]
 yttrium = { path = "../yttrium", features = ["uniffi"] }
@@ -36,3 +36,7 @@ thiserror.workspace = true
 [[bin]]
 name = "uniffi-bindgen"
 path = "uniffi-bindgen.rs"
+
+[package.metadata.cargo-udeps.ignore]
+# These crates are needed for Linux builds, but will give unused deps error when built on macOS
+normal = ["openssl", "openssl-sys"]


### PR DESCRIPTION
Changes the decode type of `eth_getUserOperationReceipt` to support `null` (via `Option`). This seems to be what Pimlico returns for the first several seconds.

Also adjusts internal code `wait_for_user_operation_receipt()` to test this. Errors will no longer be retried, only `null` response.

[Slack conversation](https://reown-inc.slack.com/archives/C03SCF66K2T/p1730728557150829)