### PR TITLE
fix: account address input source

### DIFF
--- a/crates/yttrium/src/account_client.rs
+++ b/crates/yttrium/src/account_client.rs
@@ -299,7 +299,7 @@ impl AccountClient {
 }
 
 pub async fn get_address_with_signer(
-    owner: String,
+    owner_address: String,
     chain_id: u64,
     config: Config,
     signer: Signer,
@@ -314,7 +314,7 @@ pub async fn get_address_with_signer(
             let private_key_signer: PrivateKeySigner =
                 private_key_signer_key.parse().unwrap();
             get_address_with_private_key_signer(
-                owner,
+                owner_address,
                 chain_id,
                 config,
                 private_key_signer,
@@ -332,7 +332,7 @@ pub async fn get_address_with_signer(
 }
 
 pub async fn get_address_with_private_key_signer(
-    _owner: String,
+    owner_address: String,
     chain_id: u64,
     config: Config,
     signer: PrivateKeySigner,
@@ -341,7 +341,7 @@ pub async fn get_address_with_private_key_signer(
     use crate::smart_accounts::simple_account::sender_address::get_sender_address_with_signer;
 
     let sender_address = if safe {
-        safe_test::get_address(signer, config).await?
+        safe_test::get_address(owner_address, config).await?
     } else {
         get_sender_address_with_signer(config, chain_id, signer).await?
     };

--- a/crates/yttrium/src/transaction/send/safe_test.rs
+++ b/crates/yttrium/src/transaction/send/safe_test.rs
@@ -73,16 +73,17 @@ impl fmt::Display for SentUserOperationHash {
 }
 
 pub async fn get_address(
-    owner: LocalSigner<SigningKey>,
+    owner_address: String,
     config: Config,
 ) -> eyre::Result<AccountAddress> {
     let rpc_url = config.endpoints.rpc.base_url;
     let rpc_url: reqwest::Url = rpc_url.parse()?;
     let provider = ReqwestProvider::<Ethereum>::new_http(rpc_url);
 
-    let owners = Owners { owners: vec![owner.address()], threshold: 1 };
+    let owners =
+        Owners { owners: vec![owner_address.parse().unwrap()], threshold: 1 };
 
-    Ok(get_account_address(provider.clone(), owners.clone()).await)
+    Ok(get_account_address(provider, owners).await)
 }
 
 pub async fn send_transactions(


### PR DESCRIPTION
`get_address()` was still using the legacy signer implementation. This PR removes that