### PR TITLE
fix: `NotBridgingRequired` transactions field name and visibility

### DIFF
--- a/crates/yttrium/src/chain_abstraction/api/route.rs
+++ b/crates/yttrium/src/chain_abstraction/api/route.rs
@@ -47,8 +47,7 @@ pub struct RouteResponseAvailable {
 #[cfg_attr(feature = "uniffi", derive(uniffi_macros::Record))]
 #[serde(rename_all = "camelCase")]
 pub struct RouteResponseNotRequired {
-    #[serde(rename = "transactions")]
-    _flag: Vec<String>,
+    pub transactions: Vec<Transaction>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/yttrium/src/chain_abstraction/api/route.rs
+++ b/crates/yttrium/src/chain_abstraction/api/route.rs
@@ -39,6 +39,7 @@ pub struct FundingMetadata {
 #[serde(rename_all = "camelCase")]
 pub struct RouteResponseAvailable {
     pub orchestration_id: String,
+    pub initial_transaction: Transaction,
     pub transactions: Vec<Transaction>,
     pub metadata: Metadata,
 }
@@ -47,6 +48,7 @@ pub struct RouteResponseAvailable {
 #[cfg_attr(feature = "uniffi", derive(uniffi_macros::Record))]
 #[serde(rename_all = "camelCase")]
 pub struct RouteResponseNotRequired {
+    pub initial_transaction: Transaction,
     pub transactions: Vec<Transaction>,
 }
 


### PR DESCRIPTION
This PR changes the chain orchestrator's `NotBridgingRequired` `_field` to the `transactions` and makes it public to allow the construct of the type.