### PR TITLE
fix(types): adding alias for the data and gas in the initial tx

### DIFF
--- a/crates/yttrium/src/chain_abstraction/api/mod.rs
+++ b/crates/yttrium/src/chain_abstraction/api/mod.rs
@@ -35,8 +35,10 @@ pub struct Transaction {
     pub from: Address,
     pub to: Address,
     pub value: U256,
+    #[serde(alias = "data")]
     pub input: Bytes,
 
+    #[serde(alias = "gas")]
     pub gas_limit: U64,
     pub nonce: U64,
 }


### PR DESCRIPTION
This PR adds the aliases for the `data` and `gas` for the backward compatibility.