### PR TITLE
chore: some renames & wip prepare_detailed()

### DIFF
--- a/crates/kotlin-ffi/src/lib.rs
+++ b/crates/kotlin-ffi/src/lib.rs
@@ -16,7 +16,7 @@ use {
         account_client::AccountClient as YAccountClient,
         chain_abstraction::{
             api::{
-                prepare::{PrepareResponse, RouteResponseAvailable},
+                prepare::{PrepareResponse, PrepareResponseAvailable},
                 status::{StatusResponse, StatusResponseCompleted},
                 InitialTransaction,
             },
@@ -141,7 +141,7 @@ impl ChainAbstractionClient {
 
     pub async fn get_ui_fields(
         &self,
-        route_response: RouteResponseAvailable,
+        route_response: PrepareResponseAvailable,
         currency: Currency,
     ) -> Result<UiFields, FFIError> {
         self.client

--- a/crates/yttrium/src/chain_abstraction/api/prepare.rs
+++ b/crates/yttrium/src/chain_abstraction/api/prepare.rs
@@ -96,7 +96,7 @@ impl FundingMetadata {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "uniffi", derive(uniffi_macros::Record))]
 #[serde(rename_all = "camelCase")]
-pub struct RouteResponseAvailable {
+pub struct PrepareResponseAvailable {
     pub orchestration_id: String,
     pub initial_transaction: Transaction,
     pub transactions: Vec<Transaction>,
@@ -106,7 +106,7 @@ pub struct RouteResponseAvailable {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "uniffi", derive(uniffi_macros::Record))]
 #[serde(rename_all = "camelCase")]
-pub struct RouteResponseNotRequired {
+pub struct PrepareResponseNotRequired {
     pub initial_transaction: Transaction,
     pub transactions: Vec<Transaction>,
 }
@@ -114,13 +114,13 @@ pub struct RouteResponseNotRequired {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "uniffi", derive(uniffi_macros::Enum))]
 #[serde(untagged)]
-pub enum RouteResponseSuccess {
-    Available(RouteResponseAvailable),
-    NotRequired(RouteResponseNotRequired),
+pub enum PrepareResponseSuccess {
+    Available(PrepareResponseAvailable),
+    NotRequired(PrepareResponseNotRequired),
 }
 
-impl RouteResponseSuccess {
-    pub fn into_option(self) -> Option<RouteResponseAvailable> {
+impl PrepareResponseSuccess {
+    pub fn into_option(self) -> Option<PrepareResponseAvailable> {
         match self {
             Self::Available(a) => Some(a),
             Self::NotRequired(_) => None,
@@ -132,7 +132,7 @@ impl RouteResponseSuccess {
 /// response
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "uniffi", derive(uniffi_macros::Record))]
-pub struct RouteResponseError {
+pub struct PrepareResponseError {
     pub error: BridgingError,
 }
 
@@ -149,14 +149,14 @@ pub enum BridgingError {
 #[cfg_attr(feature = "uniffi", derive(uniffi_macros::Enum))]
 #[serde(untagged)]
 pub enum PrepareResponse {
-    Success(RouteResponseSuccess),
-    Error(RouteResponseError),
+    Success(PrepareResponseSuccess),
+    Error(PrepareResponseError),
 }
 
 impl PrepareResponse {
     pub fn into_result(
         self,
-    ) -> Result<RouteResponseSuccess, RouteResponseError> {
+    ) -> Result<PrepareResponseSuccess, PrepareResponseError> {
         match self {
             Self::Success(success) => Ok(success),
             Self::Error(error) => Err(error),

--- a/crates/yttrium/src/chain_abstraction/error.rs
+++ b/crates/yttrium/src/chain_abstraction/error.rs
@@ -1,10 +1,16 @@
 use {
-    super::api::status::{StatusResponseError, StatusResponsePending},
+    super::{
+        api::{
+            prepare::{PrepareResponseError, PrepareResponseNotRequired},
+            status::{StatusResponseError, StatusResponsePending},
+        },
+        ui_fields::UiFields,
+    },
     reqwest::StatusCode,
 };
 
 #[derive(thiserror::Error, Debug)]
-pub enum RouteError {
+pub enum PrepareError {
     /// Retryable error
     #[error("HTTP request: {0}")]
     Request(reqwest::Error),
@@ -23,19 +29,7 @@ pub enum RouteError {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum WaitForSuccessError {
-    #[error("Route Error: {0}")]
-    RouteError(RouteError),
-
-    #[error("StatusResponseError: {0:?}")]
-    StatusResponseError(StatusResponseError),
-
-    #[error("StatusResponsePending: {0:?}")]
-    StatusResponsePending(StatusResponsePending),
-}
-
-#[derive(thiserror::Error, Debug)]
-pub enum RouteUiFieldsError {
+pub enum UiFieldsError {
     /// Retryable error
     #[error("HTTP request: {0}")]
     Request(reqwest::Error),
@@ -47,4 +41,59 @@ pub enum RouteUiFieldsError {
     /// Retryable error
     #[error("Json request: {0}")]
     Json(reqwest::Error),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum PrepareDetailedError {
+    #[error("Prepare Error: {0}")]
+    Prepare(PrepareError),
+
+    #[error("UiFieldsError: {0}")]
+    UiFields(UiFieldsError),
+}
+
+#[derive(Debug)]
+#[cfg_attr(feature = "uniffi", derive(uniffi_macros::Enum))]
+pub enum PrepareDetailedResponse {
+    Success(PrepareDetailedResponseSuccess),
+    Error(PrepareResponseError),
+}
+
+#[derive(Debug)]
+#[cfg_attr(feature = "uniffi", derive(uniffi_macros::Enum))]
+pub enum PrepareDetailedResponseSuccess {
+    Available(UiFields),
+    NotRequired(PrepareResponseNotRequired),
+}
+
+impl PrepareDetailedResponseSuccess {
+    pub fn into_option(self) -> Option<UiFields> {
+        match self {
+            Self::Available(a) => Some(a),
+            Self::NotRequired(_) => None,
+        }
+    }
+}
+
+impl PrepareDetailedResponse {
+    pub fn into_result(
+        self,
+    ) -> Result<PrepareDetailedResponseSuccess, PrepareResponseError> {
+        match self {
+            Self::Success(success) => Ok(success),
+            Self::Error(error) => Err(error),
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum WaitForSuccessError {
+    #[error("Prepare Error: {0}")]
+    Prepare(PrepareError),
+
+    #[error("StatusResponseError: {0:?}")]
+    StatusResponseError(StatusResponseError),
+
+    #[error("StatusResponsePending: {0:?}")]
+    StatusResponsePending(StatusResponsePending),
 }

--- a/crates/yttrium/src/chain_abstraction/tests.rs
+++ b/crates/yttrium/src/chain_abstraction/tests.rs
@@ -3,7 +3,9 @@ use {
         chain_abstraction::{
             amount::Amount,
             api::{
-                prepare::{BridgingError, PrepareResponse, RouteResponseError},
+                prepare::{
+                    BridgingError, PrepareResponse, PrepareResponseError,
+                },
                 status::StatusResponse,
                 InitialTransaction, Transaction,
             },
@@ -1664,7 +1666,7 @@ async fn bridging_routes_routes_insufficient_funds() {
     let result = client.prepare(transaction.clone()).await.unwrap();
     assert_eq!(
         result,
-        PrepareResponse::Error(RouteResponseError {
+        PrepareResponse::Error(PrepareResponseError {
             error: BridgingError::InsufficientFunds,
         })
     );

--- a/crates/yttrium/src/chain_abstraction/ui_fields.rs
+++ b/crates/yttrium/src/chain_abstraction/ui_fields.rs
@@ -2,7 +2,7 @@ use {
     super::{
         amount::Amount,
         api::{
-            prepare::RouteResponseAvailable, FeeEstimatedTransaction,
+            prepare::PrepareResponseAvailable, FeeEstimatedTransaction,
             Transaction,
         },
     },
@@ -42,7 +42,7 @@ pub struct TransactionFee {
 }
 
 pub fn ui_fields(
-    route_response: RouteResponseAvailable,
+    route_response: PrepareResponseAvailable,
     estimated_transactions: Vec<(Transaction, Eip1559Estimation, U256)>,
     estimated_initial_transaction: (Transaction, Eip1559Estimation, U256),
     fungibles: Vec<FungiblePriceItem>,
@@ -252,7 +252,7 @@ mod tests {
         };
 
         let fields = ui_fields(
-            RouteResponseAvailable {
+            PrepareResponseAvailable {
                 orchestration_id: "".to_owned(),
                 metadata: Metadata {
                     funding_from: vec![FundingMetadata {


### PR DESCRIPTION
Adds a WIP `prepare_detailed()` (for https://linear.app/reown/issue/WK-389/use-yttrium-for-txn-sending-1-function-prepare) and also does some remaining renames from `route()` -> `prepare()`

Depends on https://github.com/reown-com/yttrium/pull/101