### PR TITLE
chore: benchmark profiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,12 +135,12 @@ jobs:
 
       - name: Build Rust library
         run: |
-          cargo ndk -t ${{ matrix.target }} build --release --features=uniffi/cli
+          cargo ndk -t ${{ matrix.target }} build --profile=uniffi-release --features=uniffi/cli
 
       - name: Generate Kotlin bindings (once)
         if: ${{ matrix.target == 'aarch64-linux-android' }}
         run: |
-          cargo run --features=uniffi/cli --bin uniffi-bindgen generate --library target/${{ matrix.target }}/release/libuniffi_yttrium.so --language kotlin --out-dir yttrium/kotlin-bindings
+          cargo run --features=uniffi/cli --bin uniffi-bindgen generate --library target/${{ matrix.target }}/uniffi-release/libuniffi_yttrium.so --language kotlin --out-dir yttrium/kotlin-bindings
 
       - name: Prepare artifacts
         run: |
@@ -156,7 +156,7 @@ jobs:
           fi
 
           mkdir -p yttrium/libs/$abi_name
-          cp target/${{ matrix.target }}/release/libuniffi_yttrium.so yttrium/libs/$abi_name/
+          cp target/${{ matrix.target }}/uniffi-release/libuniffi_yttrium.so yttrium/libs/$abi_name/
 
 
   flutter:

--- a/.github/workflows/release-dart.yml
+++ b/.github/workflows/release-dart.yml
@@ -116,7 +116,7 @@ jobs:
         working-directory: crates/yttrium_dart/rust
         run: |
           rustup target add armv7-linux-androideabi aarch64-linux-android
-          cargo ndk -t armeabi-v7a -t arm64-v8a build --release
+          cargo ndk -t armeabi-v7a -t arm64-v8a build --profile=uniffi-release
 
       # Prepare Android artifacts
       - name: Prepare Android artifacts
@@ -124,8 +124,8 @@ jobs:
         run: |
           mkdir -p jniLibs/arm64-v8a
           mkdir -p jniLibs/armeabi-v7a
-          cp target/aarch64-linux-android/release/libyttrium_dart.so jniLibs/arm64-v8a/libyttrium_dart.so
-          cp target/armv7-linux-androideabi/release/libyttrium_dart.so jniLibs/armeabi-v7a/libyttrium_dart.so
+          cp target/aarch64-linux-android/uniffi-release/libyttrium_dart.so jniLibs/arm64-v8a/libyttrium_dart.so
+          cp target/armv7-linux-androideabi/uniffi-release/libyttrium_dart.so jniLibs/armeabi-v7a/libyttrium_dart.so
 
       # Upload Android artifacts
       - name: Upload Android artifacts
@@ -149,15 +149,15 @@ jobs:
         working-directory: crates/yttrium_dart/rust
         run: |
           rustup target add aarch64-apple-ios x86_64-apple-ios
-          cargo build --manifest-path Cargo.toml --target aarch64-apple-ios --release
-          cargo build --manifest-path Cargo.toml --target x86_64-apple-ios --release
+          cargo build --manifest-path Cargo.toml --target aarch64-apple-ios --profile=uniffi-release
+          cargo build --manifest-path Cargo.toml --target x86_64-apple-ios --profile=uniffi-release
 
       # Prepare iOS artifacts
       - name: Prepare iOS artifacts
         shell: bash
         run: |
           mkdir -p universal
-          lipo -create target/aarch64-apple-ios/release/libyttrium_dart.dylib target/x86_64-apple-ios/release/libyttrium_dart.dylib -output universal/libyttrium_dart_universal.dylib
+          lipo -create target/aarch64-apple-ios/uniffi-release/libyttrium_dart.dylib target/x86_64-apple-ios/uniffi-release/libyttrium_dart.dylib -output universal/libyttrium_dart_universal.dylib
           install_name_tool -id @rpath/libyttrium_dart_universal.dylib universal/libyttrium_dart_universal.dylib
           codesign --force --sign - universal/libyttrium_dart_universal.dylib
 

--- a/.github/workflows/release-kotlin.yml
+++ b/.github/workflows/release-kotlin.yml
@@ -58,12 +58,17 @@ jobs:
 
       - name: Build Rust library
         run: |
-          cargo ndk -t ${{ matrix.target }} build --profile=uniffi-release --features=uniffi/cli
+          cargo ndk -t ${{ matrix.target }} build --profile=uniffi-release-next --features=uniffi/cli
 
       - name: Generate Kotlin bindings (once)
         if: ${{ matrix.target == 'aarch64-linux-android' }}
         run: |
-          cargo run --features=uniffi/cli --bin uniffi-bindgen generate --library target/${{ matrix.target }}/uniffi-release/libuniffi_yttrium.so --language kotlin --out-dir yttrium/kotlin-bindings
+          cargo run --features=uniffi/cli --bin uniffi-bindgen generate --library target/${{ matrix.target }}/uniffi-release-next/libuniffi_yttrium.so --language kotlin --out-dir yttrium/kotlin-bindings
+
+      - name: Strip binaries
+        run: |
+            NDK_PATH=$ANDROID_HOME/ndk/27.2.12479018
+            $NDK_PATH/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip target/${{ matrix.target }}/uniffi-release-next/libuniffi_yttrium.so
 
       - name: Prepare artifacts
         run: |
@@ -79,7 +84,7 @@ jobs:
           fi
 
           mkdir -p yttrium/libs/$abi_name
-          cp target/${{ matrix.target }}/uniffi-release/libuniffi_yttrium.so yttrium/libs/$abi_name/
+          cp target/${{ matrix.target }}/uniffi-release-next/libuniffi_yttrium.so yttrium/libs/$abi_name/
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release-kotlin.yml
+++ b/.github/workflows/release-kotlin.yml
@@ -84,7 +84,7 @@ jobs:
           fi
 
           mkdir -p yttrium/libs/$abi_name
-          cp target/${{ matrix.target }}/uniffi-release-next/libuniffi_yttrium.so yttrium/libs/$abi_name/
+          cp target/${{ matrix.target }}/uniffi-release-kotlin/libuniffi_yttrium.so yttrium/libs/$abi_name/
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release-kotlin.yml
+++ b/.github/workflows/release-kotlin.yml
@@ -58,12 +58,12 @@ jobs:
 
       - name: Build Rust library
         run: |
-          cargo ndk -t ${{ matrix.target }} build --release --features=uniffi/cli
+          cargo ndk -t ${{ matrix.target }} build --profile=uniffi-release --features=uniffi/cli
 
       - name: Generate Kotlin bindings (once)
         if: ${{ matrix.target == 'aarch64-linux-android' }}
         run: |
-          cargo run --features=uniffi/cli --bin uniffi-bindgen generate --library target/${{ matrix.target }}/release/libuniffi_yttrium.so --language kotlin --out-dir yttrium/kotlin-bindings
+          cargo run --features=uniffi/cli --bin uniffi-bindgen generate --library target/${{ matrix.target }}/uniffi-release/libuniffi_yttrium.so --language kotlin --out-dir yttrium/kotlin-bindings
 
       - name: Prepare artifacts
         run: |
@@ -79,7 +79,7 @@ jobs:
           fi
 
           mkdir -p yttrium/libs/$abi_name
-          cp target/${{ matrix.target }}/release/libuniffi_yttrium.so yttrium/libs/$abi_name/
+          cp target/${{ matrix.target }}/uniffi-release/libuniffi_yttrium.so yttrium/libs/$abi_name/
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release-kotlin.yml
+++ b/.github/workflows/release-kotlin.yml
@@ -58,17 +58,17 @@ jobs:
 
       - name: Build Rust library
         run: |
-          cargo ndk -t ${{ matrix.target }} build --profile=uniffi-release-next --features=uniffi/cli
+          cargo ndk -t ${{ matrix.target }} build --profile=uniffi-release-kotlin --features=uniffi/cli
 
       - name: Generate Kotlin bindings (once)
         if: ${{ matrix.target == 'aarch64-linux-android' }}
         run: |
-          cargo run --features=uniffi/cli --bin uniffi-bindgen generate --library target/${{ matrix.target }}/uniffi-release-next/libuniffi_yttrium.so --language kotlin --out-dir yttrium/kotlin-bindings
+          cargo run --features=uniffi/cli --bin uniffi-bindgen generate --library target/${{ matrix.target }}/uniffi-release-kotlin/libuniffi_yttrium.so --language kotlin --out-dir yttrium/kotlin-bindings
 
       - name: Strip binaries
         run: |
             NDK_PATH=$ANDROID_HOME/ndk/27.2.12479018
-            $NDK_PATH/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip target/${{ matrix.target }}/uniffi-release-next/libuniffi_yttrium.so
+            $NDK_PATH/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip target/${{ matrix.target }}/uniffi-release-kotlin/libuniffi_yttrium.so
 
       - name: Prepare artifacts
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ Utilities/InstalledSwiftPMConfiguration/config.json
 /crates/kotlin-ffi/android/build
 
 *.env.secret*
+benchmark-profile-output-sizes.csv

--- a/.jitpack.yml
+++ b/.jitpack.yml
@@ -23,7 +23,7 @@ before_install:
     - mkdir -p crates/kotlin-ffi/android/src/main/jniLibs/armeabi-v7a
     - mkdir -p crates/kotlin-ffi/android/src/main/kotlin/com/reown/yttrium
     - echo "Moving binaries and bindings"
-    - mv binaries/yttrium/libs/arm64-v8a/libuniffi_yttrium.so crates/kotlin-ffi/android/src/main/jniLibs/arm64-v8a/ || echo "Failed to move arm64-v8a .so"
-    - mv binaries/yttrium/libs/armeabi-v7a/libuniffi_yttrium.so crates/kotlin-ffi/android/src/main/jniLibs/armeabi-v7a/ || echo "Failed to move armeabi-v7a .so"
+    - mv binaries/yttrium/libs/arm64-v8a/libuniffi_yttrium.so crates/kotlin-ffi/android/src/main/jniLibs/arm64-v8a/ || echo "Failed to move arm64-v8a.so"
+    - mv binaries/yttrium/libs/armeabi-v7a/libuniffi_yttrium.so crates/kotlin-ffi/android/src/main/jniLibs/armeabi-v7a/ || echo "Failed to move armeabi-v7a.so"
     - mv binaries/yttrium/kotlin-bindings/uniffi/uniffi_yttrium/uniffi_yttrium.kt crates/kotlin-ffi/android/src/main/kotlin/com/reown/yttrium/ || echo "Failed to move uniffi_yttrium.kt"
     - mv binaries/yttrium/kotlin-bindings/uniffi/yttrium/yttrium.kt crates/kotlin-ffi/android/src/main/kotlin/com/reown/yttrium/ || echo "Failed to move yttrium.kt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,20 +43,128 @@ uniffi_build = { git = "https://github.com/mozilla/uniffi-rs", rev = "e796e00ad1
 uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "e796e00ad150f8b14b61a859a2e8c6497b35074e", default-features = false, features = ["tokio"] }
 uniffi_macros = { git = "https://github.com/mozilla/uniffi-rs", rev = "e796e00ad150f8b14b61a859a2e8c6497b35074e", default-features = false }
 
+# For building release-optimized binaries for UniFFI bindings
+[profile.uniffi-release]
+inherits = "uniffi-release-v1"
+
+# TODO: consider more profiles for Kotlin vs Swift, and for Flutter, etc.
+
+[profile.uniffi-release-v1]
 # The values have been configured this way to prevent crashes in Swift debug builds with the default settings.
-[profile.release]
+inherits = "release"
 debug = true
 lto = true
 opt-level = 0
-
-
 codegen-units = 1
 # panic = "abort"
 # strip = true - it removes kotlin-bindings
 
+# What we should aim for short-term
+[profile.uniffi-release-next]
+inherits = "profile7"
+# profile7-nightly-stdopt
 
-# [profile.dev]
-# debug = 0
+[profile.uniffi-release-iter1]
+inherits = "release"
+debug = true
+lto = true
+opt-level = 3
+codegen-units = 1
+
+[profile.uniffi-release-iter2]
+inherits = "release"
+lto = true
+opt-level = 3
+codegen-units = 1
+
+[profile.uniffi-release-iter3] # same as profile7
+inherits = "release"
+lto = true
+opt-level = 3
+codegen-units = 1
+strip = true
+
+[profile.uniffi-release-iter4]
+inherits = "release"
+lto = true
+opt-level = 3
+codegen-units = 1
+strip = true
+# profile7-nightly
+
+[profile.uniffi-release-iter5]
+inherits = "release"
+lto = true
+opt-level = 3
+codegen-units = 1
+strip = true
+# profile7-nightly-stdopt
+
+[profile.profile1]
+inherits = "release"
+debug = true
+opt-level = 0
+
+[profile.profile2]
+inherits = "release"
+opt-level = 0
+
+[profile.profile21]
+inherits = "release"
+opt-level = 1
+
+[profile.profile22]
+inherits = "release"
+opt-level = 2
+
+[profile.profile3]
+inherits = "release"
+opt-level = 3
+
+[profile.profile4]
+inherits = "release"
+opt-level = "z"
+
+[profile.profile5]
+inherits = "release"
+opt-level = 3
+codegen-units = 1
+
+[profile.profile6]
+inherits = "release"
+opt-level = 3
+codegen-units = 1
+lto = true
+
+[profile.profile7]
+inherits = "release"
+opt-level = 3
+codegen-units = 1
+lto = true
+strip = true
+
+[profile.profile8]
+inherits = "release"
+opt-level = 3
+codegen-units = 1
+lto = true
+panic = "abort"
+
+[profile.profile9]
+inherits = "release"
+opt-level = 3
+codegen-units = 1
+lto = true
+strip = true
+panic = "abort"
+
+# Optimise libstd: https://github.com/johnthagen/min-sized-rust?tab=readme-ov-file#optimize-libstd-with-build-std
+# Compress the binary (not library?): https://github.com/johnthagen/min-sized-rust?tab=readme-ov-file#compress-the-binary
+
+# Questions:
+# What flags cause crash in prod Swift?
+# Can we use strip=true? Kotlin previously removed
+# Can we use panic=abort? I think for now we shouldn't due to incomplete error handling coverage, but we should in the future
 
 # [patch."https://github.com/reown-com/erc6492.git"]
 # erc6492 = { path = "../erc6492-rs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ codegen-units = 1
 
 # What we should aim for short-term
 [profile.uniffi-release-next]
-inherits = "profile7"
+inherits = "profile8"
 # profile7-nightly-stdopt
 
 [profile.uniffi-release-iter1]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,10 @@ uniffi_macros = { git = "https://github.com/mozilla/uniffi-rs", rev = "e796e00ad
 [profile.uniffi-release]
 inherits = "uniffi-release-v1"
 
+[profile.uniffi-release-v2] # Simply turns off debugging
+inherits = "uniffi-release-v1"
+debug = false
+
 # TODO: consider more profiles for Kotlin vs Swift, and for Flutter, etc.
 
 [profile.uniffi-release-v1]
@@ -67,14 +71,14 @@ inherits = "profile8"
 [profile.uniffi-release-kotlin]
 inherits = "profile11"
 
-[profile.uniffi-release-iter1]
+[profile.uniffi-release-iter1] # first iteration, changes opt-level to 3
 inherits = "release"
 debug = true
 lto = true
 opt-level = 3
 codegen-units = 1
 
-[profile.uniffi-release-iter2]
+[profile.uniffi-release-iter2] # same as profile6
 inherits = "release"
 lto = true
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,9 @@ codegen-units = 1
 inherits = "profile8"
 # profile7-nightly-stdopt
 
+[profile.uniffi-release-kotlin]
+inherits = "profile11"
+
 [profile.uniffi-release-iter1]
 inherits = "release"
 debug = true
@@ -164,6 +167,13 @@ opt-level = "z"
 codegen-units = 1
 lto = true
 strip = true
+panic = "abort"
+
+[profile.profile11]
+inherits = "release"
+opt-level = "z"
+codegen-units = 1
+lto = true
 panic = "abort"
 
 # Optimise libstd: https://github.com/johnthagen/min-sized-rust?tab=readme-ov-file#optimize-libstd-with-build-std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,6 +158,14 @@ lto = true
 strip = true
 panic = "abort"
 
+[profile.profile10]
+inherits = "release"
+opt-level = "z"
+codegen-units = 1
+lto = true
+strip = true
+panic = "abort"
+
 # Optimise libstd: https://github.com/johnthagen/min-sized-rust?tab=readme-ov-file#optimize-libstd-with-build-std
 # Compress the binary (not library?): https://github.com/johnthagen/min-sized-rust?tab=readme-ov-file#compress-the-binary
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ To contribute to this project, ensure you have the following dependencies instal
 - `swiftc` and Xcode
 - `make`
 
+```bash
+rustup toolchain install nightly -t armv7-linux-androideabi,aarch64-linux-android -c rust-src
+```
+
 ### Setup
 
 After installing the above dependencies, you can run `just ci` to run the checks that CI does and initialize your repo.

--- a/benchmark-profile-output-sizes.sh
+++ b/benchmark-profile-output-sizes.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -eo pipefail
+
+# Pre-ran output can be found here and is updated periodically:
+# https://docs.google.com/spreadsheets/d/1Ko7TmIbNrgB2PWN8cPDM4GL6Iy2d8c-VrD0FnQ9SicI/edit?usp=sharing
+
+output="benchmark-profile-output-sizes.csv"
+echo "profile,libuniffi_yttrium.a,libuniffi_yttrium.dylib" > $output
+
+echo "debug"
+cargo build
+file1="target/debug/libuniffi_yttrium.a"
+file2="target/debug/libuniffi_yttrium.dylib"
+file_size1=$(stat -f%z $file1)
+file_size2=$(stat -f%z $file2)
+echo "debug,$file_size1,$file_size2" >> $output
+
+profiles="release uniffi-release profile1 profile2 profile21 profile22 profile3 profile4 profile5 profile6 profile7 profile8 profile9"
+for profile in $profiles; do
+  echo "$profile"
+  cargo build --profile $profile
+  file1="target/$profile/libuniffi_yttrium.a"
+  file2="target/$profile/libuniffi_yttrium.dylib"
+  file_size1=$(stat -f%z $file1)
+  file_size2=$(stat -f%z $file2)
+  echo "$profile,$file_size1,$file_size2" >> $output
+done
+
+stdopt_profiles="profile6 profile7 profile8 profile9"
+for profile in $stdopt_profiles; do
+  echo "$profile"
+  cargo +nightly build --profile $profile --target-dir="target/nightly"
+  file1="target/nightly/$profile/libuniffi_yttrium.a"
+  file2="target/nightly/$profile/libuniffi_yttrium.dylib"
+  file_size1=$(stat -f%z $file1)
+  file_size2=$(stat -f%z $file2)
+  echo "$profile-nightly,$file_size1,$file_size2" >> $output
+
+  cargo +nightly build \
+    -Z build-std=std,panic_abort \
+    -Z build-std-features="optimize_for_size" \
+    --target aarch64-apple-darwin --profile $profile --target-dir="target/nightly-stdopt"
+  stdoptfile1="target/nightly-stdopt/aarch64-apple-darwin/$profile/libuniffi_yttrium.a"
+  stdoptfile2="target/nightly-stdopt/aarch64-apple-darwin/$profile/libuniffi_yttrium.dylib"
+  stdoptfile_size1=$(stat -f%z $stdoptfile1)
+  stdoptfile_size2=$(stat -f%z $stdoptfile2)
+  echo "$profile-nightly-stdopt,$stdoptfile_size1,$stdoptfile_size2" >> $output
+
+  RUSTFLAGS="-Zlocation-detail=none -Zfmt-debug=none" cargo +nightly build \
+    -Z build-std=std,panic_abort \
+    -Z build-std-features="optimize_for_size" \
+    --target aarch64-apple-darwin --profile $profile --target-dir="target/nightly-stdopt-extra"
+  stdoptextrafile1="target/nightly-stdopt-extra/aarch64-apple-darwin/$profile/libuniffi_yttrium.a"
+  stdoptextrafile2="target/nightly-stdopt-extra/aarch64-apple-darwin/$profile/libuniffi_yttrium.dylib"
+  stdoptextrafile_size1=$(stat -f%z $stdoptextrafile1)
+  stdoptextrafile_size2=$(stat -f%z $stdoptextrafile2)
+  echo "$profile-nightly-stdopt-extra,$stdoptextrafile_size1,$stdoptextrafile_size2" >> $output
+done

--- a/benchmark-profile-output-sizes.sh
+++ b/benchmark-profile-output-sizes.sh
@@ -5,54 +5,108 @@ set -eo pipefail
 # https://docs.google.com/spreadsheets/d/1Ko7TmIbNrgB2PWN8cPDM4GL6Iy2d8c-VrD0FnQ9SicI/edit?usp=sharing
 
 output="benchmark-profile-output-sizes.csv"
-echo "profile,libuniffi_yttrium.a,libuniffi_yttrium.dylib" > $output
+echo "profile,libuniffi_yttrium.a,libuniffi_yttrium.dylib,libuniffi_yttrium.so.aarch64,libuniffi_yttrium.so.armv7" > $output
 
-echo "debug"
-cargo build
-file1="target/debug/libuniffi_yttrium.a"
-file2="target/debug/libuniffi_yttrium.dylib"
-file_size1=$(stat -f%z $file1)
-file_size2=$(stat -f%z $file2)
-echo "debug,$file_size1,$file_size2" >> $output
+# echo "debug"
+# cargo build
+# cargo ndk -t armeabi-v7a -t arm64-v8a build --features=uniffi/cli
+# file1="target/debug/libuniffi_yttrium.a"
+# file2="target/debug/libuniffi_yttrium.dylib"
+# file3="target/aarch64-linux-android/debug/libuniffi_yttrium.so"
+# file4="target/armv7-linux-androideabi/debug/libuniffi_yttrium.so"
+# file_size1=$(stat -f%z $file1)
+# file_size2=$(stat -f%z $file2)
+# file_size3=$(stat -f%z $file3)
+# file_size4=$(stat -f%z $file4)
+# echo "debug,$file_size1,$file_size2,$file_size3,$file_size4" >> $output
 
-profiles="release uniffi-release profile1 profile2 profile21 profile22 profile3 profile4 profile5 profile6 profile7 profile8 profile9"
+# profiles="release uniffi-release uniffi-release-v2 profile1 profile2 profile21 profile22 profile3 profile4 profile5 profile6 profile7 profile8 profile9"
+profiles="profile6 profile8 profile9 profile10"
 for profile in $profiles; do
   echo "$profile"
   cargo build --profile $profile
+  cargo ndk -t armeabi-v7a -t arm64-v8a build --profile=$profile --features=uniffi/cli
   file1="target/$profile/libuniffi_yttrium.a"
   file2="target/$profile/libuniffi_yttrium.dylib"
+  file3="target/aarch64-linux-android/$profile/libuniffi_yttrium.so"
+  file4="target/armv7-linux-androideabi/$profile/libuniffi_yttrium.so"
   file_size1=$(stat -f%z $file1)
   file_size2=$(stat -f%z $file2)
-  echo "$profile,$file_size1,$file_size2" >> $output
+  file_size3=$(stat -f%z $file3)
+  file_size4=$(stat -f%z $file4)
+  echo "$profile,$file_size1,$file_size2,$file_size3,$file_size4" >> $output
 done
 
-stdopt_profiles="profile6 profile7 profile8 profile9"
+# stdopt_profiles="uniffi-release-v2 profile6 profile7 profile8 profile9"
+stdopt_profiles="profile6 profile8 profile9 profile10"
 for profile in $stdopt_profiles; do
   echo "$profile"
+  echo "build1"
   cargo +nightly build --profile $profile --target-dir="target/nightly"
+  echo "build2"
+  cargo +nightly ndk -t armeabi-v7a -t arm64-v8a build --profile=$profile --features=uniffi/cli --target-dir="target/nightly"
   file1="target/nightly/$profile/libuniffi_yttrium.a"
   file2="target/nightly/$profile/libuniffi_yttrium.dylib"
+  file3="target/nightly/aarch64-linux-android/$profile/libuniffi_yttrium.so"
+  file4="target/nightly/armv7-linux-androideabi/$profile/libuniffi_yttrium.so"
   file_size1=$(stat -f%z $file1)
   file_size2=$(stat -f%z $file2)
-  echo "$profile-nightly,$file_size1,$file_size2" >> $output
-
+  file_size3=$(stat -f%z $file3)
+  file_size4=$(stat -f%z $file4)
+  echo "$profile-nightly,$file_size1,$file_size2,$file_size3,$file_size4" >> $output
+  
+  echo "build3"
   cargo +nightly build \
     -Z build-std=std,panic_abort \
     -Z build-std-features="optimize_for_size" \
     --target aarch64-apple-darwin --profile $profile --target-dir="target/nightly-stdopt"
+  echo "build4"
+  cargo +nightly ndk \
+    -t armeabi-v7a -t arm64-v8a build --profile=$profile --features=uniffi/cli --target-dir="target/nightly-stdopt" \
+    -Z build-std=std,panic_abort \
+    -Z build-std-features="optimize_for_size"
   stdoptfile1="target/nightly-stdopt/aarch64-apple-darwin/$profile/libuniffi_yttrium.a"
   stdoptfile2="target/nightly-stdopt/aarch64-apple-darwin/$profile/libuniffi_yttrium.dylib"
+  stdoptfile3="target/nightly-stdopt/aarch64-linux-android/$profile/libuniffi_yttrium.so"
+  stdoptfile4="target/nightly-stdopt/armv7-linux-androideabi/$profile/libuniffi_yttrium.so"
   stdoptfile_size1=$(stat -f%z $stdoptfile1)
   stdoptfile_size2=$(stat -f%z $stdoptfile2)
-  echo "$profile-nightly-stdopt,$stdoptfile_size1,$stdoptfile_size2" >> $output
+  stdoptfile_size3=$(stat -f%z $stdoptfile3)
+  stdoptfile_size4=$(stat -f%z $stdoptfile4)
+  echo "$profile-nightly-stdopt,$stdoptfile_size1,$stdoptfile_size2,$stdoptfile_size3,$stdoptfile_size4" >> $output
 
+  echo "build5"
   RUSTFLAGS="-Zlocation-detail=none -Zfmt-debug=none" cargo +nightly build \
     -Z build-std=std,panic_abort \
     -Z build-std-features="optimize_for_size" \
     --target aarch64-apple-darwin --profile $profile --target-dir="target/nightly-stdopt-extra"
+  echo "build6"
+  RUSTFLAGS="-Zlocation-detail=none -Zfmt-debug=none" cargo +nightly ndk \
+    -t armeabi-v7a -t arm64-v8a build --profile=$profile --features=uniffi/cli --target-dir="target/nightly-stdopt-extra" \
+    -Z build-std=std,panic_abort \
+    -Z build-std-features="optimize_for_size"
   stdoptextrafile1="target/nightly-stdopt-extra/aarch64-apple-darwin/$profile/libuniffi_yttrium.a"
   stdoptextrafile2="target/nightly-stdopt-extra/aarch64-apple-darwin/$profile/libuniffi_yttrium.dylib"
+  stdoptextrafile3="target/nightly-stdopt-extra/aarch64-linux-android/$profile/libuniffi_yttrium.so"
+  stdoptextrafile4="target/nightly-stdopt-extra/armv7-linux-androideabi/$profile/libuniffi_yttrium.so"
   stdoptextrafile_size1=$(stat -f%z $stdoptextrafile1)
   stdoptextrafile_size2=$(stat -f%z $stdoptextrafile2)
-  echo "$profile-nightly-stdopt-extra,$stdoptextrafile_size1,$stdoptextrafile_size2" >> $output
+  stdoptextrafile_size3=$(stat -f%z $stdoptextrafile3)
+  stdoptextrafile_size4=$(stat -f%z $stdoptextrafile4)
+  echo "$profile-nightly-stdopt-extra,$stdoptextrafile_size1,$stdoptextrafile_size2,$stdoptextrafile_size3,$stdoptextrafile_size4" >> $output
+done
+
+# extra2: adds panic_immediate_abort
+stdopt_profiles="profile8 profile9 profile10"
+for profile in $stdopt_profiles; do
+  echo "build7"
+  RUSTFLAGS="-Zlocation-detail=none -Zfmt-debug=none" cargo +nightly ndk \
+    -t armeabi-v7a -t arm64-v8a build --profile=$profile --features=uniffi/cli --target-dir="target/nightly-stdopt-extra2" \
+    -Z build-std=std,panic_abort \
+    -Z build-std-features="optimize_for_size,panic_immediate_abort"
+  stdoptextra2file3="target/nightly-stdopt-extra2/aarch64-linux-android/$profile/libuniffi_yttrium.so"
+  stdoptextra2file4="target/nightly-stdopt-extra2/armv7-linux-androideabi/$profile/libuniffi_yttrium.so"
+  stdoptextra2file_size3=$(stat -f%z $stdoptextra2file3)
+  stdoptextra2file_size4=$(stat -f%z $stdoptextra2file4)
+  echo "$profile-nightly-stdopt-extra2,N/A,N/A,$stdoptextra2file_size3,$stdoptextra2file_size4" >> $output
 done

--- a/crates/kotlin-ffi/uniffi.toml
+++ b/crates/kotlin-ffi/uniffi.toml
@@ -1,3 +1,7 @@
 [bindings.kotlin]
 android = true
 android_cleaner = true
+# omit_checksums = true
+
+# [bindings.swift]
+# omit_checksums = true

--- a/crates/yttrium/src/examples/eip7702_smart_sessions.rs
+++ b/crates/yttrium/src/examples/eip7702_smart_sessions.rs
@@ -53,6 +53,12 @@ use {
     std::time::Duration,
 };
 
+// Odyssey onramp
+// cast send 0x9228665c0D8f9Fc36843572bE50B716B81e042BA \
+//     --value 0.00001ether \
+//     --mnemonic $FAUCET_MNEMONIC \
+//     --rpc-url https://gateway.tenderly.co/public/sepolia
+
 #[tokio::test]
 #[ignore]
 #[cfg(feature = "test_pimlico_api")]

--- a/crates/yttrium/src/smart_accounts/safe.rs
+++ b/crates/yttrium/src/smart_accounts/safe.rs
@@ -393,12 +393,13 @@ pub fn prepare_sign(
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum SignOutputEnum {
     Signature(Bytes),
-    SignOutput(SignOutput),
+    // renamed to `Object` to avoid conflicts: https://github.com/mozilla/uniffi-rs/issues/2402
+    SignOutput(SignOutputObject),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
-pub struct SignOutput {
+pub struct SignOutputObject {
     pub to_sign: SignOutputToSign,
     pub sign_step_3_params: SignStep3Params,
 }
@@ -461,7 +462,7 @@ where
         )
         .await?;
 
-        Ok(SignOutputEnum::SignOutput(SignOutput {
+        Ok(SignOutputEnum::SignOutput(SignOutputObject {
             to_sign: SignOutputToSign { hash, safe_op, domain },
             sign_step_3_params: SignStep3Params {
                 signature,

--- a/crates/yttrium/src/transaction_sponsorship/mod.rs
+++ b/crates/yttrium/src/transaction_sponsorship/mod.rs
@@ -329,6 +329,7 @@ impl Client {
             .provider_pool
             .get_provider(&format!("eip155:{chain_id}"))
             .await;
+
         let sponsor = if let Some(sponsor) = sponsor {
             sponsor
         } else {

--- a/crates/yttrium/src/transaction_sponsorship/tests.rs
+++ b/crates/yttrium/src/transaction_sponsorship/tests.rs
@@ -82,8 +82,7 @@ async fn happy_path() {
         // Display fee information to the user: prepare_deploy_result.fees
         // User approved? Yes
 
-        let signature: alloy::signers::Signature =
-            eoa.sign_hash_sync(&prepared_send.hash).unwrap();
+        let signature = eoa.sign_hash_sync(&prepared_send.hash).unwrap();
         let receipt = client.send(signature, prepared_send.send_params).await;
         println!("receipt: {:?}", receipt);
     }

--- a/crates/yttrium/src/uniffi_compat.rs
+++ b/crates/yttrium/src/uniffi_compat.rs
@@ -172,7 +172,7 @@ pub struct FfiAuthorization {
 mod tests {
     use {
         super::*,
-        alloy::primitives::{address, bytes},
+        alloy::primitives::{address, bytes, U32},
     };
 
     #[test]
@@ -221,5 +221,33 @@ mod tests {
         let s: String =
             ::uniffi::FfiConverter::<crate::UniFfiTag>::try_lift(u).unwrap();
         assert_eq!(s, format!("0xaabbccdd"));
+    }
+
+    #[test]
+    fn test_u32_raise() {
+        let s = "0x1";
+        let n = s.parse::<U32>().unwrap();
+        assert_eq!(n, Uint::from(1));
+    }
+
+    #[test]
+    fn test_u64_raise() {
+        let s = "0x1";
+        let n = s.parse::<U64>().unwrap();
+        assert_eq!(n, Uint::from(1));
+    }
+
+    #[test]
+    fn test_u128_raise() {
+        let s = "0x1";
+        let n = s.parse::<U128>().unwrap();
+        assert_eq!(n, Uint::from(1));
+    }
+
+    #[test]
+    fn test_u256_raise() {
+        let s = "0x1";
+        let n = s.parse::<U256>().unwrap();
+        assert_eq!(n, Uint::from(1));
     }
 }

--- a/crates/yttrium_dart/generate_android_lib.sh
+++ b/crates/yttrium_dart/generate_android_lib.sh
@@ -4,7 +4,7 @@
 cd rust
 
 rustup target add armv7-linux-androideabi aarch64-linux-android x86_64-linux-android i686-linux-android
-cargo ndk -t armeabi-v7a -t arm64-v8a -t x86_64 -t x86 build --release
+cargo ndk -t armeabi-v7a -t arm64-v8a -t x86_64 -t x86 build --profile=uniffi-release
 
 cd .. #/yttrium_dart
 
@@ -16,7 +16,7 @@ mkdir -p android/src/main/jniLibs/armeabi-v7a
 cd .. #/crates
 cd .. #/yttrium
 
-cp target/aarch64-linux-android/release/libyttrium_dart.so crates/yttrium_dart/android/src/main/jniLibs/arm64-v8a/libyttrium_dart.so
-cp target/armv7-linux-androideabi/release/libyttrium_dart.so crates/yttrium_dart/android/src/main/jniLibs/armeabi-v7a/libyttrium_dart.so
-# cp target/i686-linux-android/release/libyttrium_dart.so crates/yttrium_dart/android/src/main/jniLibs/x86/libyttrium_dart.so
-# cp target/x86_64-linux-android/release/libyttrium_dart.so crates/yttrium_dart/android/src/main/jniLibs/x86_64/libyttrium_dart.so
+cp target/aarch64-linux-android/uniffi-release/libyttrium_dart.so crates/yttrium_dart/android/src/main/jniLibs/arm64-v8a/libyttrium_dart.so
+cp target/armv7-linux-androideabi/uniffi-release/libyttrium_dart.so crates/yttrium_dart/android/src/main/jniLibs/armeabi-v7a/libyttrium_dart.so
+# cp target/i686-linux-android/uniffi-release/libyttrium_dart.so crates/yttrium_dart/android/src/main/jniLibs/x86/libyttrium_dart.so
+# cp target/x86_64-linux-android/uniffi-release/libyttrium_dart.so crates/yttrium_dart/android/src/main/jniLibs/x86_64/libyttrium_dart.so

--- a/crates/yttrium_dart/generate_ios_lib.sh
+++ b/crates/yttrium_dart/generate_ios_lib.sh
@@ -29,20 +29,20 @@ echo "✅ $0: building for targest: x86_64-apple-ios $TARGET."
 
 rustup target add x86_64-apple-ios $TARGET
 
-cargo build --manifest-path Cargo.toml --target x86_64-apple-ios --release
-cargo build --manifest-path Cargo.toml --target $TARGET --release
+cargo build --manifest-path Cargo.toml --target x86_64-apple-ios --profile=uniffi-release
+cargo build --manifest-path Cargo.toml --target $TARGET --profile=uniffi-release
 
 cd .. #/yttrium_dart
 cd .. #/crates
 cd .. #/yttrium
 
-mkdir -p target/universal/ios/release
+mkdir -p target/universal/ios/uniffi-release
 
-lipo -create target/$TARGET/release/libyttrium_dart.dylib target/x86_64-apple-ios/release/libyttrium_dart.dylib -output target/universal/ios/release/libyttrium_dart_universal.dylib
+lipo -create target/$TARGET/uniffi-release/libyttrium_dart.dylib target/x86_64-apple-ios/uniffi-release/libyttrium_dart.dylib -output target/universal/ios/uniffi-release/libyttrium_dart_universal.dylib
 
-lipo -info target/universal/ios/release/libyttrium_dart_universal.dylib
+lipo -info target/universal/ios/uniffi-release/libyttrium_dart_universal.dylib
 
-cp target/universal/ios/release/libyttrium_dart_universal.dylib crates/yttrium_dart/ios/libyttrium_dart_universal.dylib
+cp target/universal/ios/uniffi-release/libyttrium_dart_universal.dylib crates/yttrium_dart/ios/libyttrium_dart_universal.dylib
 
 # otool -L crates/yttrium_dart/ios/libyttrium_dart_universal.dylib
 

--- a/crates/yttrium_dart/lib/generated/frb_generated.dart
+++ b/crates/yttrium_dart/lib/generated/frb_generated.dart
@@ -72,7 +72,7 @@ class YttriumDart extends BaseEntrypoint<YttriumDartApi, YttriumDartApiImpl,
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
     stem: 'yttrium_dart',
-    ioDirectory: 'rust/target/release/',
+    ioDirectory: 'rust/target/uniffi-release/',
     webPrefix: 'pkg/',
   );
 }

--- a/crates/yttrium_dart/lib/generated/frb_generated.dart
+++ b/crates/yttrium_dart/lib/generated/frb_generated.dart
@@ -72,7 +72,7 @@ class YttriumDart extends BaseEntrypoint<YttriumDartApi, YttriumDartApiImpl,
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
     stem: 'yttrium_dart',
-    ioDirectory: 'rust/target/uniffi-release/',
+    ioDirectory: 'rust/target/release/',
     webPrefix: 'pkg/',
   );
 }

--- a/generate_kotlin_locally.sh
+++ b/generate_kotlin_locally.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+rm -rf crates/kotlin-ffi/android/src/main/jniLibs/arm64-v8a/
+rm -rf crates/kotlin-ffi/android/src/main/jniLibs/armeabi-v7a/
+rm -rf crates/kotlin-ffi/android/src/main/kotlin/com/reown/yttrium/
+
+cargo ndk -t armeabi-v7a -t arm64-v8a build --profile=uniffi-release-next --features=uniffi/cli
+cargo run --features=uniffi/cli --bin uniffi-bindgen generate --library target/aarch64-linux-android/uniffi-release-next/libuniffi_yttrium.so --language kotlin --out-dir yttrium/kotlin-bindings
+
+mkdir -p crates/kotlin-ffi/android/src/main/jniLibs/arm64-v8a
+mkdir -p crates/kotlin-ffi/android/src/main/jniLibs/armeabi-v7a
+mkdir -p crates/kotlin-ffi/android/src/main/kotlin/com/reown/yttrium
+
+echo "Moving binaries and bindings"
+mv target/aarch64-linux-android/uniffi-release-next/libuniffi_yttrium.so crates/kotlin-ffi/android/src/main/jniLibs/arm64-v8a/
+mv target/armv7-linux-androideabi/uniffi-release-next/libuniffi_yttrium.so crates/kotlin-ffi/android/src/main/jniLibs/armeabi-v7a/
+mv yttrium/kotlin-bindings/uniffi/uniffi_yttrium/uniffi_yttrium.kt crates/kotlin-ffi/android/src/main/kotlin/com/reown/yttrium/
+mv yttrium/kotlin-bindings/uniffi/yttrium/yttrium.kt crates/kotlin-ffi/android/src/main/kotlin/com/reown/yttrium/
+
+$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-strip crates/kotlin-ffi/android/src/main/jniLibs/arm64-v8a/libuniffi_yttrium.so
+$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-strip crates/kotlin-ffi/android/src/main/jniLibs/armeabi-v7a/libuniffi_yttrium.so
+
+gradle clean assembleRelease publishToMavenLocal

--- a/generate_kotlin_locally.sh
+++ b/generate_kotlin_locally.sh
@@ -4,16 +4,16 @@ rm -rf crates/kotlin-ffi/android/src/main/jniLibs/arm64-v8a/
 rm -rf crates/kotlin-ffi/android/src/main/jniLibs/armeabi-v7a/
 rm -rf crates/kotlin-ffi/android/src/main/kotlin/com/reown/yttrium/
 
-cargo ndk -t armeabi-v7a -t arm64-v8a build --profile=uniffi-release-next --features=uniffi/cli
-cargo run --features=uniffi/cli --bin uniffi-bindgen generate --library target/aarch64-linux-android/uniffi-release-next/libuniffi_yttrium.so --language kotlin --out-dir yttrium/kotlin-bindings
+cargo ndk -t armeabi-v7a -t arm64-v8a build --profile=uniffi-release-kotlin --features=uniffi/cli
+cargo run --features=uniffi/cli --bin uniffi-bindgen generate --library target/aarch64-linux-android/uniffi-release-kotlin/libuniffi_yttrium.so --language kotlin --out-dir yttrium/kotlin-bindings
 
 mkdir -p crates/kotlin-ffi/android/src/main/jniLibs/arm64-v8a
 mkdir -p crates/kotlin-ffi/android/src/main/jniLibs/armeabi-v7a
 mkdir -p crates/kotlin-ffi/android/src/main/kotlin/com/reown/yttrium
 
 echo "Moving binaries and bindings"
-mv target/aarch64-linux-android/uniffi-release-next/libuniffi_yttrium.so crates/kotlin-ffi/android/src/main/jniLibs/arm64-v8a/
-mv target/armv7-linux-androideabi/uniffi-release-next/libuniffi_yttrium.so crates/kotlin-ffi/android/src/main/jniLibs/armeabi-v7a/
+mv target/aarch64-linux-android/uniffi-release-kotlin/libuniffi_yttrium.so crates/kotlin-ffi/android/src/main/jniLibs/arm64-v8a/
+mv target/armv7-linux-androideabi/uniffi-release-kotlin/libuniffi_yttrium.so crates/kotlin-ffi/android/src/main/jniLibs/armeabi-v7a/
 mv yttrium/kotlin-bindings/uniffi/uniffi_yttrium/uniffi_yttrium.kt crates/kotlin-ffi/android/src/main/kotlin/com/reown/yttrium/
 mv yttrium/kotlin-bindings/uniffi/yttrium/yttrium.kt crates/kotlin-ffi/android/src/main/kotlin/com/reown/yttrium/
 

--- a/justfile
+++ b/justfile
@@ -71,4 +71,4 @@ swift:
   make CONFIG=debug build-swift-apple-platforms
 
 kotlin:
-  # TODO
+  cargo ndk -t armeabi-v7a -t arm64-v8a build --profile=uniffi-release --features=uniffi/cli

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -4,7 +4,7 @@ set -e
 set -u
 
 PACKAGE_NAME="uniffi_yttrium"
-fat_simulator_lib_dir="target/ios-simulator-fat/release"
+fat_simulator_lib_dir="target/ios-simulator-fat/uniffi-release"
 swift_package_dir="platforms/swift/Sources/Yttrium"
 
 build_rust_libraries() {
@@ -18,7 +18,7 @@ build_rust_libraries() {
   export RUSTFLAGS="-C linker=$CC_aarch64_apple_ios -C link-arg=-miphoneos-version-min=13.0"
 
   # Build
-  cargo build --lib --release --target aarch64-apple-ios
+  cargo build --lib --profile=uniffi-release --target aarch64-apple-ios
 
   # Unset environment variables
   unset CC_aarch64_apple_ios
@@ -36,7 +36,7 @@ build_rust_libraries() {
   export RUSTFLAGS="-C linker=$CC_x86_64_apple_ios -C link-arg=-mios-simulator-version-min=13.0"
 
   # Build
-  cargo build --lib --release --target x86_64-apple-ios
+  cargo build --lib --profile=uniffi-release --target x86_64-apple-ios
 
   # Unset environment variables
   unset CC_x86_64_apple_ios
@@ -54,7 +54,7 @@ build_rust_libraries() {
   export RUSTFLAGS="-C linker=$CC_aarch64_apple_ios_sim -C link-arg=-mios-simulator-version-min=13.0"
 
   # Build
-  cargo build --lib --release --target aarch64-apple-ios-sim
+  cargo build --lib --profile=uniffi-release --target aarch64-apple-ios-sim
 
   # Unset environment variables
   unset CC_aarch64_apple_ios_sim
@@ -66,7 +66,7 @@ build_rust_libraries() {
 generate_ffi() {
   echo "Generating framework module mapping and FFI bindings..."
   cargo run --features uniffi/cli --bin uniffi-bindgen generate \
-      --library target/aarch64-apple-ios/release/lib$1.dylib \
+      --library target/aarch64-apple-ios/uniffi-release/lib$1.dylib \
       --language swift \
       --out-dir target/uniffi-xcframework-staging
 
@@ -85,8 +85,8 @@ create_fat_simulator_lib() {
   echo "Creating a fat library for x86_64 and aarch64 simulators..."
   mkdir -p "$fat_simulator_lib_dir"
   lipo -create \
-      target/x86_64-apple-ios/release/lib$1.a \
-      target/aarch64-apple-ios-sim/release/lib$1.a \
+      target/x86_64-apple-ios/uniffi-release/lib$1.a \
+      target/aarch64-apple-ios-sim/uniffi-release/lib$1.a \
       -output "$fat_simulator_lib_dir/lib$1.a"
 }
 
@@ -95,7 +95,7 @@ build_xcframework() {
   rm -rf target/ios
   mkdir -p target/ios
   xcodebuild -create-xcframework \
-      -library target/aarch64-apple-ios/release/lib$1.a -headers target/uniffi-xcframework-staging \
+      -library target/aarch64-apple-ios/uniffi-release/lib$1.a -headers target/uniffi-xcframework-staging \
       -library "$fat_simulator_lib_dir/lib$1.a" -headers target/uniffi-xcframework-staging \
       -output target/ios/lib$1.xcframework
 }


### PR DESCRIPTION
- Rename the profile bindings are generated with from `release` to `uniffi-release`
- Add various other profiles with various configurations
- Add script to test all of these profiles and record the results in a CSV

https://docs.google.com/spreadsheets/d/1Ko7TmIbNrgB2PWN8cPDM4GL6Iy2d8c-VrD0FnQ9SicI/edit?gid=21763173#gid=21763173

From the above sheet:
- Short-term goal is `profile7-nightly-stdopt`, but we may hit issues
- Long-term we may be able to achieve `profile9-nightly-stdopt`, but it requires us to be very careful with our panics and it makes debugging them much more difficult