### PR TITLE
chore: add yttrium version info to CA requests

### DIFF
--- a/crates/yttrium/build.rs
+++ b/crates/yttrium/build.rs
@@ -1,0 +1,19 @@
+fn main() {
+    let git_hash = match std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+    {
+        Ok(output) => match String::from_utf8(output.stdout) {
+            Ok(output) => output,
+            Err(e) => {
+                println!("Failed to get GET_HASH (in getting string from output): {e}");
+                "unknown-string".to_string()
+            }
+        },
+        Err(e) => {
+            println!("Failed to get GET_HASH (in calling git): {e}");
+            "unknown-git".to_string()
+        }
+    };
+    println!("cargo:rustc-env=GIT_HASH={git_hash}");
+}

--- a/crates/yttrium/src/chain_abstraction/api/fungible_price.rs
+++ b/crates/yttrium/src/chain_abstraction/api/fungible_price.rs
@@ -23,6 +23,8 @@ pub struct PriceRequestBody {
     pub project_id: ProjectId,
     pub currency: Currency,
     pub addresses: HashSet<String>,
+    #[serde(default)]
+    pub sdk_versions: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
@@ -44,4 +46,40 @@ pub struct FungiblePriceItem {
         serialize_with = "crate::utils::serialize_unit"
     )]
     pub decimals: Unit,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn price_request_body_parse_deserialization() {
+        let json =
+            serde_json::from_value::<PriceRequestBody>(serde_json::json!({
+                "projectId": "project_id",
+                "currency": "usd",
+                "addresses": [],
+                "sdkVersions": "yttrium-1234567",
+            }))
+            .unwrap();
+        assert_eq!(json.project_id, "project_id".into());
+        assert_eq!(json.currency, Currency::Usd);
+        assert_eq!(json.addresses, HashSet::new());
+        assert_eq!(json.sdk_versions, "yttrium-1234567");
+    }
+
+    #[test]
+    fn price_request_body_parse_backwards_compat() {
+        let json =
+            serde_json::from_value::<PriceRequestBody>(serde_json::json!({
+                "projectId": "project_id",
+                "currency": "usd",
+                "addresses": [],
+            }))
+            .unwrap();
+        assert_eq!(json.project_id, "project_id".into());
+        assert_eq!(json.currency, Currency::Usd);
+        assert_eq!(json.addresses, HashSet::new());
+        assert_eq!(json.sdk_versions, "");
+    }
 }

--- a/crates/yttrium/src/chain_abstraction/api/prepare.rs
+++ b/crates/yttrium/src/chain_abstraction/api/prepare.rs
@@ -12,6 +12,8 @@ pub const ROUTE_ENDPOINT_PATH: &str = "/v1/ca/orchestrator/route";
 #[serde(rename_all = "camelCase")]
 pub struct RouteQueryParams {
     pub project_id: ProjectId,
+    #[serde(default)]
+    pub sdk_versions: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -286,5 +288,28 @@ mod tests {
         assert_eq!(calls[0].to, to);
         assert_eq!(calls[0].value, value);
         assert_eq!(calls[0].input, input);
+    }
+
+    #[test]
+    fn route_query_params_parse_deserialization() {
+        let json =
+            serde_json::from_value::<RouteQueryParams>(serde_json::json!({
+                "projectId": "project_id",
+                "sdkVersions": "yttrium-1234567",
+            }))
+            .unwrap();
+        assert_eq!(json.project_id, "project_id".into());
+        assert_eq!(json.sdk_versions, "yttrium-1234567");
+    }
+
+    #[test]
+    fn route_query_params_parse_backwards_compat() {
+        let json =
+            serde_json::from_value::<RouteQueryParams>(serde_json::json!({
+                "projectId": "project_id",
+            }))
+            .unwrap();
+        assert_eq!(json.project_id, "project_id".into());
+        assert_eq!(json.sdk_versions, "");
     }
 }

--- a/crates/yttrium/src/chain_abstraction/client.rs
+++ b/crates/yttrium/src/chain_abstraction/client.rs
@@ -30,6 +30,7 @@ use {
         },
         erc20::ERC20,
         provider_pool::ProviderPool,
+        version::format_sdk_version,
     },
     alloy::{
         network::TransactionBuilder,
@@ -78,6 +79,7 @@ impl Client {
             })
             .query(&RouteQueryParams {
                 project_id: self.provider_pool.project_id.clone(),
+                sdk_versions: format_sdk_version(),
             })
             .send()
             .await
@@ -142,6 +144,7 @@ impl Client {
                         project_id: self.provider_pool.project_id.clone(),
                         currency: local_currency,
                         addresses: HashSet::from([address]),
+                        sdk_versions: format_sdk_version(),
                     })
                     .send()
                     .await

--- a/crates/yttrium/src/lib.rs
+++ b/crates/yttrium/src/lib.rs
@@ -24,6 +24,7 @@ pub mod test_helpers;
 pub mod transaction_sponsorship;
 pub mod user_operation;
 pub mod utils;
+pub mod version;
 
 #[cfg(test)]
 pub mod examples;

--- a/crates/yttrium/src/version.rs
+++ b/crates/yttrium/src/version.rs
@@ -1,0 +1,23 @@
+pub const GIT_HASH: &str = env!("GIT_HASH");
+
+pub fn format_sdk_version() -> String {
+    format!("yttrium-{GIT_HASH}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_sdk_version() {
+        assert_eq!(format_sdk_version(), format!("yttrium-{GIT_HASH}"));
+    }
+
+    #[test]
+    #[allow(clippy::const_is_empty)]
+    fn test_git_hash() {
+        assert_ne!(GIT_HASH, "unknown");
+        assert!(!GIT_HASH.is_empty());
+        assert_eq!(GIT_HASH.len(), 40);
+    }
+}


### PR DESCRIPTION
Starts passing yttrium commit hash to Blockchain API. This gives an initial start at versioning so we have _something_, as well as a solid foundation to understand issues if other version info workflows fail.

From here, we will add methods/parameters for WalletKit to pass its own version info and add it to the list of versions passed.

Fixes WK-403