### PR TITLE
fix: wasm time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3192,7 +3192,7 @@ dependencies = [
  "number_prefix",
  "portable-atomic",
  "unicode-width",
- "web-time",
+ "web-time 1.1.0",
 ]
 
 [[package]]
@@ -4160,7 +4160,7 @@ dependencies = [
  "thiserror 2.0.11",
  "tinyvec",
  "tracing",
- "web-time",
+ "web-time 1.1.0",
 ]
 
 [[package]]
@@ -4596,7 +4596,7 @@ version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 dependencies = [
- "web-time",
+ "web-time 1.1.0",
 ]
 
 [[package]]
@@ -6038,6 +6038,17 @@ dependencies = [
 
 [[package]]
 name = "web-time"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa75ec260dcf59cc310827bae1d7f629809b173dbfe808a633e19754dd4282a5"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
@@ -6077,7 +6088,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6391,6 +6402,7 @@ dependencies = [
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "web-time 0.1.0",
  "wiremock",
 ]
 

--- a/crates/yttrium/Cargo.toml
+++ b/crates/yttrium/Cargo.toml
@@ -75,6 +75,8 @@ uuid = { version = "1.12.1", default-features = false, features = [
     "serde",
 ] }
 
+web-time = { version = "0.1.0", default-features = false }
+
 # Error/Result
 eyre.workspace = true
 thiserror.workspace = true

--- a/crates/yttrium/src/bundler/client.rs
+++ b/crates/yttrium/src/bundler/client.rs
@@ -140,10 +140,7 @@ impl BundlerClient {
         &self,
         hash: B256,
     ) -> eyre::Result<UserOperationReceipt> {
-        use {
-            std::time::{Duration, Instant},
-            tokio::time::sleep,
-        };
+        use {std::time::Duration, tokio::time::sleep, web_time::Instant};
 
         let polling_interval = Duration::from_millis(2000);
         let timeout = Some(Duration::from_secs(30));

--- a/crates/yttrium/src/chain_abstraction/client.rs
+++ b/crates/yttrium/src/chain_abstraction/client.rs
@@ -47,8 +47,9 @@ use {
     serde::{Deserialize, Serialize},
     std::{
         collections::{HashMap, HashSet},
-        time::{Duration, Instant, SystemTime},
+        time::Duration,
     },
+    web_time::{Instant, SystemTime},
 };
 
 #[derive(Clone)]

--- a/crates/yttrium/src/chain_abstraction/pulse.rs
+++ b/crates/yttrium/src/chain_abstraction/pulse.rs
@@ -4,9 +4,9 @@ use {
     relay_rpc::domain::ProjectId,
     reqwest::{Client, Url},
     serde::{Deserialize, Serialize},
-    std::time::SystemTime,
     tracing::{debug, warn},
     uuid::Uuid,
+    web_time::SystemTime,
 };
 
 // const PULSE_ENDPOINT: &str = "https://analytics-api-cf-workers-staging.walletconnect-v1-bridge.workers.dev/e";

--- a/crates/yttrium/src/chain_abstraction/send_transaction.rs
+++ b/crates/yttrium/src/chain_abstraction/send_transaction.rs
@@ -11,7 +11,8 @@ use {
     },
     alloy_provider::Provider,
     serde::{Deserialize, Serialize},
-    std::time::{Duration, Instant, SystemTime},
+    std::time::Duration,
+    web_time::{Instant, SystemTime},
 };
 
 pub async fn send_transaction(

--- a/crates/yttrium/src/chain_abstraction/tests.rs
+++ b/crates/yttrium/src/chain_abstraction/tests.rs
@@ -34,13 +34,8 @@ use {
     alloy_provider::{Network, Provider, ProviderBuilder, RootProvider},
     relay_rpc::domain::ProjectId,
     serial_test::serial,
-    std::{
-        cmp::max,
-        collections::HashMap,
-        iter,
-        sync::Arc,
-        time::{Duration, Instant},
-    },
+    std::{cmp::max, collections::HashMap, iter, sync::Arc, time::Duration},
+    web_time::Instant,
     ERC20::ERC20Instance,
 };
 

--- a/crates/yttrium/src/serde.rs
+++ b/crates/yttrium/src/serde.rs
@@ -23,7 +23,7 @@ pub mod systemtime_millis {
     use {
         super::duration_millis,
         serde::{de, ser},
-        std::time::{SystemTime, UNIX_EPOCH},
+        web_time::{SystemTime, UNIX_EPOCH},
     };
 
     pub fn serialize<S>(

--- a/crates/yttrium/src/test_helpers/mod.rs
+++ b/crates/yttrium/src/test_helpers/mod.rs
@@ -6,7 +6,8 @@ use {
         signers::{k256::ecdsa::SigningKey, local::LocalSigner},
     },
     alloy_provider::{ext::AnvilApi, Provider, ProviderBuilder},
-    std::time::{Duration, Instant},
+    std::time::Duration,
+    web_time::Instant,
 };
 
 pub fn private_faucet() -> LocalSigner<SigningKey> {


### PR DESCRIPTION
Adds compatibility for `Instant` and `SystemTime` on wasm targets

[Slack conversation](https://reown-inc.slack.com/archives/C07HQ8RCGD8/p1739368853019669?thread_ts=1739366533.563759&cid=C07HQ8RCGD8)