### PR TITLE
ci: use `macos-14` instead of expensive `macos-latest-xlarge`

### DIFF
--- a/.github/workflows/release-dart.yml
+++ b/.github/workflows/release-dart.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   install-dependencies:
-    runs-on: macos-latest-xlarge
+    runs-on: macos-14
 
     steps:
       # Checkout repository


### PR DESCRIPTION
## Context

- See: https://reown-inc.slack.com/archives/C07HQ8RCGD8/p1740049847785069