### PR TITLE
fix: verify sigs

### DIFF
--- a/crates/yttrium/src/chain_abstraction/client.rs
+++ b/crates/yttrium/src/chain_abstraction/client.rs
@@ -466,6 +466,26 @@ impl Client {
             "route_txn_sigs length must match route length"
         );
 
+        for (index, (txn, sig)) in
+            ui_fields.route.iter().zip(route_txn_sigs.iter()).enumerate()
+        {
+            let address = sig
+                .recover_address_from_prehash(&txn.transaction_hash_to_sign)
+                .unwrap();
+            let expected_address = txn.transaction.from;
+            assert_eq!(address, expected_address, "invalid route signature at index {index}. Expected recovered address to be {expected_address} but got {address} instead");
+        }
+
+        {
+            let address = initial_txn_sig
+                .recover_address_from_prehash(
+                    &ui_fields.initial.transaction_hash_to_sign,
+                )
+                .unwrap();
+            let expected_address = ui_fields.initial.transaction.from;
+            assert_eq!(address, expected_address, "invalid initial txn signature. Expected recovered address to be {expected_address} but got {address} instead");
+        }
+
         let result = self
             .execute_inner(ui_fields, route_txn_sigs, initial_txn_sig)
             .await;


### PR DESCRIPTION
Adds more parameter assertions for checking that transaction signatures are correct. This is a panic because it indicates an implementation problem with the wallet and should be caught during development.

This is in-response to issues implementing sample wallets that incorrectly sign the transaction, but get confusing and hard-to-debug gas-related errors. By pre-validating the signatures here we can catch the issue earlier and provide a better error message to developers.

Resolves WK-573