### PR TITLE
feat(CA): extending an error object with the `reason` field

### DIFF
--- a/crates/yttrium/src/chain_abstraction/api/prepare.rs
+++ b/crates/yttrium/src/chain_abstraction/api/prepare.rs
@@ -211,7 +211,7 @@ impl PrepareResponseSuccess {
 #[serde(rename_all = "camelCase")]
 pub struct PrepareResponseError {
     pub error: BridgingError,
-    pub reason: Option<String>,
+    pub reason: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/yttrium/src/chain_abstraction/api/prepare.rs
+++ b/crates/yttrium/src/chain_abstraction/api/prepare.rs
@@ -211,6 +211,7 @@ impl PrepareResponseSuccess {
 #[serde(rename_all = "camelCase")]
 pub struct PrepareResponseError {
     pub error: BridgingError,
+    pub reason: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/yttrium/src/chain_abstraction/tests.rs
+++ b/crates/yttrium/src/chain_abstraction/tests.rs
@@ -2142,6 +2142,7 @@ async fn bridging_routes_routes_insufficient_funds() {
         result,
         PrepareResponse::Error(PrepareResponseError {
             error: BridgingError::InsufficientFunds,
+            reason: None,
         })
     );
 }

--- a/crates/yttrium/src/chain_abstraction/tests.rs
+++ b/crates/yttrium/src/chain_abstraction/tests.rs
@@ -2138,11 +2138,11 @@ async fn bridging_routes_routes_insufficient_funds() {
         )
         .await
         .unwrap();
-    assert_eq!(
+    assert!(matches!(
         result,
         PrepareResponse::Error(PrepareResponseError {
             error: BridgingError::InsufficientFunds,
-            reason: None,
+            ..
         })
-    );
+    ));
 }


### PR DESCRIPTION
This PR extends Chain Abstraction `PrepareResponseError` with the new `reason` field to contain an error message/description addition to the error type.

This change is a dependency of https://github.com/reown-com/blockchain-api/pull/976