### PR TITLE
feat(CA): adding `AssetNotSupported` error type

### DIFF
--- a/crates/yttrium/src/chain_abstraction/api/prepare.rs
+++ b/crates/yttrium/src/chain_abstraction/api/prepare.rs
@@ -375,6 +375,7 @@ pub struct PrepareResponseError {
 )]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum BridgingError {
+    AssetNotSupported,
     NoRoutesAvailable,
     InsufficientFunds,
     InsufficientGasFunds,


### PR DESCRIPTION
This PR adds a new `AssetNotSupported` error type for cases where we know that the initial transaction will fail (insufficient balance), but the possible funding asset is not supported for bridging.
The full context: https://reown-inc.slack.com/archives/C0816SK4877/p1741702145995839