### PR TITLE
feat(CA): adding `TransactionSimulationFailed` error type

### DIFF
--- a/crates/yttrium/src/chain_abstraction/api/prepare.rs
+++ b/crates/yttrium/src/chain_abstraction/api/prepare.rs
@@ -403,6 +403,7 @@ pub enum BridgingError {
     NoRoutesAvailable,
     InsufficientFunds,
     InsufficientGasFunds,
+    TransactionSimulationFailed,
     #[serde(other)]
     Unknown,
 }


### PR DESCRIPTION
This PR adds a new `TransactionSimulationFailed` error type for the Chain Abstraction route response.
This will properly handle cases where the broken initial transaction was pushed to the route, and we know that the transaction will fail when we are making a simulation for getting asset changes.