### PR TITLE
Add self_public_key to Session after Approval

### DIFF
--- a/crates/yttrium/src/sign/mod.rs
+++ b/crates/yttrium/src/sign/mod.rs
@@ -496,7 +496,10 @@ impl Client {
             }
         }
 
-        let session = Session { session_sym_key: shared_secret };
+        let session = Session {
+            session_sym_key: shared_secret,
+            self_public_key: hex::encode(self_public_key.to_bytes()),
+        };
         {
             let mut sessions = self.sessions.write().unwrap();
             sessions.insert(session_topic, session.clone());
@@ -1450,25 +1453,33 @@ impl From<SessionProposalFfi> for SessionProposal {
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct Session {
     pub session_sym_key: [u8; 32],
+    pub self_public_key: String,
 }
 
 #[cfg(feature = "uniffi")]
 #[derive(uniffi_macros::Record)]
 pub struct SessionFfi {
     pub session_sym_key: Vec<u8>,
+    pub self_public_key: String,
 }
 
 #[cfg(feature = "uniffi")]
 impl From<Session> for SessionFfi {
     fn from(session: Session) -> Self {
-        Self { session_sym_key: session.session_sym_key.to_vec() }
+        Self {
+            session_sym_key: session.session_sym_key.to_vec(),
+            self_public_key: session.self_public_key,
+        }
     }
 }
 
 #[cfg(feature = "uniffi")]
 impl From<SessionFfi> for Session {
     fn from(session: SessionFfi) -> Self {
-        Self { session_sym_key: session.session_sym_key.try_into().unwrap() }
+        Self {
+            session_sym_key: session.session_sym_key.try_into().unwrap(),
+            self_public_key: session.self_public_key,
+        }
     }
 }
 


### PR DESCRIPTION
Added `pair_json` and `approve_json` methods on Rust side to be used specifically by Flutter SDK to avoid mappings boilerplate

Added `self_public_key` in `approve` response as both web and flutter responds with a complete Session object after approval that includes self_public_key. Before introducing rust client this was generated on core on the specific platform but now self_public_key is generated on rust side.

Web: https://github.com/WalletConnect/walletconnect-monorepo/blob/494a945678d44df55162cf37bdbb9e80a6a35b1d/packages/sign-client/src/controllers/engine.ts#L444

Flutter: https://github.com/reown-com/reown_flutter/blob/2192103999db0bb3482f624d20df727ec7fa0213/packages/reown_sign/lib/sign_engine.dart#L355