### PR TITLE
Fix Swift Utils Release Process to Comply with Branch Protection Rules

### DIFF
--- a/.github/workflows/publish-swift-utils.yml
+++ b/.github/workflows/publish-swift-utils.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
 
       - name: Configure Git
@@ -36,12 +37,21 @@ jobs:
         id: version
         run: |
           LABEL_PREFIX="${{ env.PR_LABEL }}="
-          VERSION_LABEL=$(jq -r --arg prefix "$LABEL_PREFIX" 'first(.event.pull_request.labels[]?.name | select(startswith($prefix)))' "$GITHUB_EVENT_PATH")
+          VERSION_LABEL=$(jq -r --arg prefix "$LABEL_PREFIX" 'first(.pull_request.labels[]?.name | select(startswith($prefix)))' "$GITHUB_EVENT_PATH")
           if [ -z "$VERSION_LABEL" ]; then
             echo "::error::Unable to determine version label starting with ${LABEL_PREFIX}" >&2
             exit 1
           fi
           VERSION=${VERSION_LABEL#${LABEL_PREFIX}}
+          if [ -z "$VERSION" ]; then
+            echo "::error::Version extracted from label '${VERSION_LABEL}' is empty" >&2
+            exit 1
+          fi
+          # Validate version format (basic semver check)
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "::error::Invalid version format: ${VERSION}. Expected semver (e.g., 0.1.0)" >&2
+            exit 1
+          fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Swift Utils release version: ${VERSION}" >> "$GITHUB_STEP_SUMMARY"
 
@@ -51,7 +61,7 @@ jobs:
           name: swift-utils-release-${{ steps.version.outputs.version }}
           path: Output/
           workflow: release-swift-utils.yml
-          branch: release/swift-utils/${{ steps.version.outputs.version }}
+          pr: ${{ github.event.pull_request.number }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify Downloaded Artifacts

--- a/.github/workflows/release-swift-utils.yml
+++ b/.github/workflows/release-swift-utils.yml
@@ -122,5 +122,5 @@ jobs:
           path: |
             Output/libyttrium-utils.xcframework.zip
             Output/libyttrium-utils-pod.zip
-          retention-days: 5
+          retention-days: 30
           if-no-files-found: error


### PR DESCRIPTION
# Fix Swift Utils Release Process to Comply with Branch Protection Rules

## Summary

Updates the Swift Utils release workflow to comply with repository branch protection rules that require "Changes must be made through a pull request" instead of direct pushes to `main`.

## Problem

### Branch Protection Violation

The repository has branch protection rules on `main` that enforce:
- **All changes must go through a pull request** (prevents direct pushes)
- This ensures code review, CI checks, and approval processes are followed
- Protects against accidental or unauthorized changes to the main branch

### What Was Failing

The existing `release-swift-utils.yml` workflow attempted to:
1. Build the XCFramework
2. Update `Package.swift` and podspec files
3. **Directly push changes to `main`** ← This violated the rule
4. Create tags and releases

This resulted in the workflow failing with:

> remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: Review all repository rules at https://github.com/reown-com/yttrium/rules?ref=refs%2Fheads%2Fmain
remote:
remote: - Changes must be made through a pull request.
remote:
To https://github.com/reown-com/yttrium
! [remote rejected] HEAD -> main (push declined due to repository rule violations)
error: failed to push some refs to 'https://github.com/reown-com/yttrium'

## Solution

Split the release process into two workflows that respect branch protection:

### `release-swift-utils.yml` (Build & PR Creation)
- Builds XCFramework and generates Swift Package metadata
- Updates `Package.swift` and `YttriumUtilsWrapper.podspec` with version & checksum
- **Creates a pull request** instead of pushing to main
- Uploads build artifacts for reuse (avoids rebuild)
- Labels PR with `swift-utils-release` and `swift-utils-release=<version>`

### `publish-swift-utils.yml` (Tag & Publish on Merge) - NEW
- Triggers when PR with `swift-utils-release` label is merged
- Extracts version from PR labels
- Downloads pre-built artifacts from the release workflow
- Tags the merge commit
- Creates GitHub release
- Uploads XCFramework zips (SPM & CocoaPods)
- Publishes to CocoaPods trunk