### PR TITLE
fix: span tracing

### DIFF
--- a/crates/yttrium/src/bin/sign_canary.rs
+++ b/crates/yttrium/src/bin/sign_canary.rs
@@ -221,6 +221,11 @@ where
         if let Some(group) = visitor.group {
             if let Some(span) = ctx.span(id) {
                 span.extensions_mut().insert(GroupExtension(group));
+            } else {
+                tracing::trace!(
+                    "Failed to lookup span {:?} for group extension insertion",
+                    id
+                );
             }
         }
     }


### PR DESCRIPTION
Fixes that the use of spans to add `group` wasn't picked up by the canary metrics code. This caused metrics to be reported without this label.

Tested by manually deploying the canary, as well as added tests.