### PR TITLE
fix: RPC ID collisions & refactor types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14955,10 +14955,12 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41ae868b5a0f67631c14589f7e250c1ea2c574ee5ba21c6c8dd4b1485705a5a1"
 dependencies = [
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime 0.7.0",
  "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
@@ -14996,6 +14998,12 @@ checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
 
 [[package]]
 name = "ton_lib"
@@ -15614,9 +15622,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uniffi"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6d968cb62160c11f2573e6be724ef8b1b18a277aededd17033f8a912d73e2b4"
+checksum = "c866f627c3f04c3df068b68bb2d725492caaa539dd313e2a9d26bb85b1a32f4e"
 dependencies = [
  "anyhow",
  "camino",
@@ -15629,9 +15637,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b39ef1acbe1467d5d210f274fae344cb6f8766339330cb4c9688752899bf6b"
+checksum = "7c8ca600167641ebe7c8ba9254af40492dda3397c528cc3b2f511bd23e8541a5"
 dependencies = [
  "anyhow",
  "askama",
@@ -15646,7 +15654,7 @@ dependencies = [
  "serde",
  "tempfile",
  "textwrap 0.16.2",
- "toml 0.5.11",
+ "toml 0.9.4",
  "uniffi_internal_macros",
  "uniffi_meta",
  "uniffi_pipeline",
@@ -15655,9 +15663,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6683e6b665423cddeacd89a3f97312cf400b2fb245a26f197adaf65c45d505b2"
+checksum = "3e55c05228f4858bb258f651d21d743fcc1fe5a2ec20d3c0f9daefddb105ee4d"
 dependencies = [
  "anyhow",
  "camino",
@@ -15666,9 +15674,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d990b553d6b9a7ee9c3ae71134674739913d52350b56152b0e613595bb5a6f"
+checksum = "7e7a5a038ebffe8f4cf91416b154ef3c2468b18e828b7009e01b1b99938089f9"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -15679,9 +15687,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f4f224becf14885c10e6e400b95cc4d1985738140cb194ccc2044563f8a56b"
+checksum = "e3c2a6f93e7b73726e2015696ece25ca0ac5a5f1cf8d6a7ab5214dd0a01d2edf"
 dependencies = [
  "anyhow",
  "indexmap 2.10.0",
@@ -15692,9 +15700,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b481d385af334871d70904e6a5f129be7cd38c18fcf8dd8fd1f646b426a56d58"
+checksum = "64c6309fc36c7992afc03bc0c5b059c656bccbef3f2a4bc362980017f8936141"
 dependencies = [
  "camino",
  "fs-err",
@@ -15703,15 +15711,15 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.104",
- "toml 0.5.11",
+ "toml 0.9.4",
  "uniffi_meta",
 ]
 
 [[package]]
 name = "uniffi_meta"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f817868a3b171bb7bf259e882138d104deafde65684689b4694c846d322491"
+checksum = "0a138823392dba19b0aa494872689f97d0ee157de5852e2bec157ce6de9cdc22"
 dependencies = [
  "anyhow",
  "siphasher 0.3.11",
@@ -15721,9 +15729,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_pipeline"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b147e133ad7824e32426b90bc41fda584363563f2ba747f590eca1fd6fd14e6"
+checksum = "8c27c4b515d25f8e53cc918e238c39a79c3144a40eaf2e51c4a7958973422c29"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -15734,9 +15742,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caed654fb73da5abbc7a7e9c741532284532ba4762d6fe5071372df22a41730a"
+checksum = "d0adacdd848aeed7af4f5af7d2f621d5e82531325d405e29463482becfdeafca"
 dependencies = [
  "anyhow",
  "textwrap 0.16.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,9 @@ chacha20poly1305 = { version = "0.11.0-pre.2", default-features = false }
 
 serial_test = { version = "3.2.0", default-features = false }
 
-uniffi_build = { version = "0.29", default-features = false }
-uniffi = { version = "0.29", default-features = false, features = ["tokio"] }
-uniffi_macros = { version = "0.29", default-features = false }
+uniffi_build = { version = "0.30.0", default-features = false }
+uniffi = { version = "0.30.0", default-features = false, features = ["tokio"] }
+uniffi_macros = { version = "0.30.0", default-features = false }
 
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"

--- a/crates/yttrium/src/sign/client.rs
+++ b/crates/yttrium/src/sign/client.rs
@@ -12,9 +12,10 @@ use {
         envelope_type0::decrypt_type0_envelope_with_hashes,
         pairing_uri,
         protocol_types::{
-            Controller, JsonRpcRequest, JsonRpcRequestParams, Metadata,
-            Proposal, ProposalJsonRpc, ProposalResponse,
-            ProposalResultResponseJsonRpc, Proposer, Relay, SessionDelete,
+            Controller, GenericJsonRpcResponseError, JsonRpcRequest,
+            JsonRpcRequestParams, JsonRpcVersion, Metadata, Proposal,
+            ProposalJsonRpc, ProposalResponse, ProposalResultResponseJsonRpc,
+            Proposer, ProtocolRpcId, Relay, SessionDelete,
             SessionDeleteJsonRpc, SessionExtend, SessionExtendJsonRpc,
             SessionRequest, SessionRequestJsonRpc,
             SessionRequestJsonRpcResponse, SessionSettle, SessionUpdate,
@@ -23,7 +24,7 @@ use {
         relay::{Attestation, AttestationCallback, IncomingSessionMessage},
         storage::Storage,
         utils::{
-            diffie_hellman, generate_rpc_id, is_expired,
+            diffie_hellman, is_expired,
             serialize_and_encrypt_message_type0_envelope,
             serialize_and_encrypt_message_type0_envelope_with_ids,
             topic_from_sym_key, DecryptedHash, EncryptedHash,
@@ -306,7 +307,7 @@ impl Client {
         } else {
             self.storage.insert_json_rpc_history(
                 request.id,
-                pairing_uri.topic.to_string(),
+                pairing_uri.topic.clone(),
                 request.method.clone(),
                 request_json,
                 Some(TransportType::Relay),
@@ -394,10 +395,10 @@ impl Client {
             expiry_timestamp: Some(expiry_timestamp),
         };
 
-        let rpc_id = generate_rpc_id();
+        let rpc_id = ProtocolRpcId::generate();
         let session_proposal_json_rpc = JsonRpcRequest {
             id: rpc_id,
-            jsonrpc: "2.0".to_string(),
+            jsonrpc: JsonRpcVersion::version_2(),
             method: "wc_sessionPropose".to_string(),
             params: JsonRpcRequestParams::SessionPropose(
                 session_proposal.clone(),
@@ -434,7 +435,7 @@ impl Client {
                         attestation,
                         analytics: Some(AnalyticsData {
                             correlation_id: Some(
-                                correlation_id.try_into().unwrap(),
+                                correlation_id.into_value() as i64
                             ),
                             chain_id: None,
                             rpc_methods: None,
@@ -452,7 +453,7 @@ impl Client {
 
         self.storage.insert_json_rpc_history(
             rpc_id,
-            pairing_info.topic.to_string(),
+            pairing_info.topic.clone(),
             "wc_sessionPropose".to_string(),
             session_proposal_params_json,
             Some(TransportType::Relay),
@@ -530,7 +531,7 @@ impl Client {
 
         let response_result_json_rpc = ProposalResultResponseJsonRpc {
             id: proposal.session_proposal_rpc_id,
-            jsonrpc: "2.0".to_string(),
+            jsonrpc: JsonRpcVersion::version_2(),
             result: ProposalResponse {
                 relay: Relay { protocol: "irn".to_string() },
                 responder_public_key: hex::encode(self_public_key.to_bytes()),
@@ -556,7 +557,7 @@ impl Client {
             .as_secs()
             + 60 * 60 * 24 * 7; // Session expiry is 7 days
 
-        let session_settlement_request_id = generate_rpc_id();
+        let session_settlement_request_id = ProtocolRpcId::generate();
         let session_settlement_request_params = SessionSettle {
             relay: Relay { protocol: "irn".to_string() },
             namespaces: approved_namespaces.clone(),
@@ -570,7 +571,7 @@ impl Client {
         };
         let session_settlement_json_rpc = JsonRpcRequest {
             id: session_settlement_request_id,
-            jsonrpc: "2.0".to_string(),
+            jsonrpc: JsonRpcVersion::version_2(),
             method: "wc_sessionSettle".to_string(),
             params: JsonRpcRequestParams::SessionSettle(
                 session_settlement_request_params.clone(),
@@ -597,7 +598,9 @@ impl Client {
             session_proposal_response,
             session_settlement_request,
             analytics: Some(AnalyticsData {
-                correlation_id: Some(proposal.session_proposal_rpc_id as i64),
+                correlation_id: Some(
+                    proposal.session_proposal_rpc_id.into_value() as i64,
+                ),
                 chain_id: None,
                 rpc_methods: None,
                 tx_hashes: None,
@@ -638,7 +641,7 @@ impl Client {
                 //Store SessionSettle Request
                 self.storage.insert_json_rpc_history(
                     session_settlement_request_id,
-                    session.topic.to_string(),
+                    session.topic.clone(),
                     "wc_sessionSettle".to_string(),
                     session_settlement_request_params_json,
                     Some(TransportType::Relay),
@@ -692,16 +695,10 @@ impl Client {
             }
         }
 
-        // Map enum to ErrorData using centralized conversion
-        let mapped_error: relay_rpc::rpc::ErrorData = reason.into();
-
-        // Send error response to the pairing topic
-        let error_response = relay_rpc::rpc::ErrorResponse {
-            id: relay_rpc::domain::MessageId::new(
-                proposal.session_proposal_rpc_id,
-            ),
-            jsonrpc: relay_rpc::rpc::JSON_RPC_VERSION.clone(),
-            error: mapped_error,
+        let error_response = GenericJsonRpcResponseError {
+            id: proposal.session_proposal_rpc_id,
+            jsonrpc: JsonRpcVersion::version_2(),
+            error: reason.into(),
         };
 
         let response_result_json =
@@ -714,7 +711,6 @@ impl Client {
         )
         .map_err(RejectError::ShouldNeverHappen)?;
 
-        // Publish error response to pairing topic
         match self
             .do_request::<bool>(relay_rpc::rpc::Params::Publish(Publish {
                 topic: proposal.pairing_topic.clone(),
@@ -725,7 +721,7 @@ impl Client {
                 prompt: false,
                 analytics: Some(AnalyticsData {
                     correlation_id: Some(
-                        proposal.session_proposal_rpc_id.try_into().unwrap(),
+                        proposal.session_proposal_rpc_id.into_value() as i64,
                     ),
                     chain_id: None,
                     rpc_methods: None,
@@ -758,7 +754,7 @@ impl Client {
         &mut self,
         topic: Topic,
         session_request: SessionRequest,
-    ) -> Result<(u64), RequestError> {
+    ) -> Result<ProtocolRpcId, RequestError> {
         let shared_secret = self
             .storage
             .get_session(topic.clone())
@@ -767,8 +763,8 @@ impl Client {
             .unwrap();
 
         let rpc = SessionRequestJsonRpc {
-            id: generate_rpc_id(),
-            jsonrpc: "2.0".to_string(),
+            id: ProtocolRpcId::generate(),
+            jsonrpc: JsonRpcVersion::version_2(),
             method: "wc_sessionRequest".to_string(),
             params: session_request,
         };
@@ -809,7 +805,7 @@ impl Client {
 
         self.storage.insert_json_rpc_history(
             rpc.id,
-            topic.to_string(),
+            topic,
             rpc.method,
             session_request_params_json,
             Some(TransportType::Relay),
@@ -850,8 +846,7 @@ impl Client {
                         SessionRequestJsonRpcResponse::Result(r) => r.id,
                         SessionRequestJsonRpcResponse::Error(e) => e.id,
                     }
-                    .try_into()
-                    .unwrap(),
+                    .into_value() as i64,
                 ),
                 chain_id: None,
                 rpc_methods: None,
@@ -913,11 +908,11 @@ impl Client {
             self.storage.add_session(session);
         }
 
-        let id = generate_rpc_id();
+        let id = ProtocolRpcId::generate();
         let session_update_json_rpc =
             crate::sign::protocol_types::SessionUpdateJsonRpc {
                 id,
-                jsonrpc: "2.0".to_string(),
+                jsonrpc: JsonRpcVersion::version_2(),
                 method: "wc_sessionUpdate".to_string(),
                 params: SessionUpdate { namespaces: namespaces.clone() },
             };
@@ -939,7 +934,7 @@ impl Client {
             tag: 1104,
             prompt: false,
             analytics: Some(AnalyticsData {
-                correlation_id: Some(id.try_into().unwrap()),
+                correlation_id: Some(id.into_value() as i64),
                 chain_id: None,
                 rpc_methods: None,
                 tx_hashes: None,
@@ -951,7 +946,7 @@ impl Client {
 
         self.storage.insert_json_rpc_history(
             id,
-            topic.to_string(),
+            topic,
             "wc_sessionUpdate".to_string(),
             namespaces_params_json,
             Some(TransportType::Relay),
@@ -985,10 +980,10 @@ impl Client {
         session.expiry = new_expiry;
         let shared_secret = session.session_sym_key;
         self.storage.add_session(session);
-        let id = generate_rpc_id();
+        let id = ProtocolRpcId::generate();
         let session_extend_json_rpc = SessionExtendJsonRpc {
             id,
-            jsonrpc: "2.0".to_string(),
+            jsonrpc: JsonRpcVersion::version_2(),
             method: "wc_sessionExtend".to_string(),
             params: SessionExtend { expiry: new_expiry },
         };
@@ -1010,7 +1005,7 @@ impl Client {
             tag: 1106,
             prompt: false,
             analytics: Some(AnalyticsData {
-                correlation_id: Some(id.try_into().unwrap()),
+                correlation_id: Some(id.into_value() as i64),
                 chain_id: None,
                 rpc_methods: None,
                 tx_hashes: None,
@@ -1022,7 +1017,7 @@ impl Client {
 
         self.storage.insert_json_rpc_history(
             id,
-            topic.to_string(),
+            topic,
             "wc_sessionExtend".to_string(),
             expiry_rpc_json,
             Some(TransportType::Relay),
@@ -1053,11 +1048,11 @@ impl Client {
             .map(|s| s.session_sym_key)
             .ok_or(EmitError::SessionNotFound)?;
 
-        let id = generate_rpc_id();
+        let id = ProtocolRpcId::generate();
         let session_event_json_rpc =
             crate::sign::protocol_types::SessionEventJsonRpc {
                 id,
-                jsonrpc: "2.0".to_string(),
+                jsonrpc: JsonRpcVersion::version_2(),
                 method: "wc_sessionEvent".to_string(),
                 params: crate::sign::protocol_types::EventParams {
                     event: crate::sign::protocol_types::SessionEventVO {
@@ -1083,7 +1078,7 @@ impl Client {
             tag: 1110,
             prompt: false,
             analytics: Some(AnalyticsData {
-                correlation_id: Some(id.try_into().unwrap()),
+                correlation_id: Some(id.into_value() as i64),
                 chain_id: None,
                 rpc_methods: None,
                 tx_hashes: None,
@@ -1095,7 +1090,7 @@ impl Client {
 
         self.storage.insert_json_rpc_history(
             id,
-            topic.to_string(),
+            topic,
             "wc_sessionEvent".to_string(),
             event_json,
             Some(TransportType::Relay),
@@ -1116,10 +1111,10 @@ impl Client {
             .map(|s| s.session_sym_key);
 
         if let Some(shared_secret) = shared_secret {
-            let id = generate_rpc_id();
+            let id = ProtocolRpcId::generate();
             let session_delete_json_rpc = SessionDeleteJsonRpc {
                 id,
-                jsonrpc: "2.0".to_string(),
+                jsonrpc: JsonRpcVersion::version_2(),
                 method: "wc_sessionDelete".to_string(),
                 params: SessionDelete {
                     code: 6000,
@@ -1151,7 +1146,7 @@ impl Client {
 
             self.storage.insert_json_rpc_history(
                 id,
-                topic.to_string(),
+                topic.clone(),
                 "wc_sessionDelete".to_string(),
                 delete_json,
                 Some(TransportType::Relay),

--- a/crates/yttrium/src/sign/client_types.rs
+++ b/crates/yttrium/src/sign/client_types.rs
@@ -1,6 +1,7 @@
 use {
     crate::sign::protocol_types::{
-        Metadata, ProposalNamespaces, Relay, SettleNamespace,
+        GenericJsonRpcResponseErrorData, Metadata, ProposalNamespaces,
+        ProtocolRpcId, Relay, SettleNamespace,
     },
     relay_rpc::domain::Topic,
     serde::{Deserialize, Serialize},
@@ -10,7 +11,7 @@ use {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionProposal {
-    pub session_proposal_rpc_id: u64,
+    pub session_proposal_rpc_id: ProtocolRpcId,
     pub pairing_topic: Topic,
     pub pairing_sym_key: [u8; 32],
     pub proposer_public_key: [u8; 32],
@@ -25,7 +26,7 @@ pub struct SessionProposal {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Session {
-    pub request_id: u64,
+    pub request_id: ProtocolRpcId,
     pub topic: Topic,
     pub expiry: u64,
     pub relay_protocol: String,
@@ -121,7 +122,7 @@ impl RejectionReason {
     }
 }
 
-impl From<RejectionReason> for relay_rpc::rpc::ErrorData {
+impl From<RejectionReason> for GenericJsonRpcResponseErrorData {
     fn from(reason: RejectionReason) -> Self {
         Self {
             code: reason.code(),

--- a/crates/yttrium/src/sign/mod.rs
+++ b/crates/yttrium/src/sign/mod.rs
@@ -2,7 +2,7 @@ pub use {
     relay::IncomingSessionMessage,
     relay_rpc::{
         auth::ed25519_dalek::{SecretKey, SigningKey},
-        domain::Topic,
+        domain::{MessageId, Topic},
         rpc::ErrorData,
     },
     verify::validate::VerifyContext,

--- a/crates/yttrium/src/sign/protocol_types/json_rpc_version.rs
+++ b/crates/yttrium/src/sign/protocol_types/json_rpc_version.rs
@@ -1,0 +1,28 @@
+use {
+    relay_rpc::rpc::JSON_RPC_VERSION,
+    serde::{Deserialize, Serialize},
+    std::{fmt::Display, sync::Arc},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct JsonRpcVersion(Arc<str>);
+
+impl JsonRpcVersion {
+    pub fn version_2() -> Self {
+        Self(JSON_RPC_VERSION.clone())
+    }
+}
+
+impl Display for JsonRpcVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+// Can't just use an Arc<str>. See https://github.com/mozilla/uniffi-rs/issues/2727
+#[cfg(feature = "uniffi")]
+uniffi::custom_type!(JsonRpcVersion, String, {
+    remote,
+    try_lift: |val| Ok(JsonRpcVersion(val.into())),
+    lower: |obj| obj.to_string(),
+});

--- a/crates/yttrium/src/sign/protocol_types/mod.rs
+++ b/crates/yttrium/src/sign/protocol_types/mod.rs
@@ -1,8 +1,11 @@
+pub use {json_rpc_version::JsonRpcVersion, rpc_id::ProtocolRpcId};
 use {
-    relay_rpc::domain::MessageId,
     serde::{Deserialize, Deserializer, Serialize},
     std::collections::HashMap,
 };
+
+mod json_rpc_version;
+mod rpc_id;
 
 fn deserialize_null_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
 where
@@ -27,9 +30,8 @@ pub mod methods {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ProposalJsonRpc {
-    // deserialize number from string (Flutter support)
-    pub id: u64,
-    pub jsonrpc: String,
+    pub id: ProtocolRpcId,
+    pub jsonrpc: JsonRpcVersion,
     pub method: String,
     pub params: Proposal,
 }
@@ -87,16 +89,16 @@ pub struct Proposer {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProposalResultResponseJsonRpc {
-    pub id: u64,
-    pub jsonrpc: String,
+    pub id: ProtocolRpcId,
+    pub jsonrpc: JsonRpcVersion,
     pub result: ProposalResponse,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProposalErrorResponseJsonRpc {
-    pub id: u64,
-    pub jsonrpc: String,
+    pub id: ProtocolRpcId,
+    pub jsonrpc: JsonRpcVersion,
     pub error: serde_json::Value,
 }
 
@@ -117,8 +119,8 @@ pub struct ProposalResponse {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonRpcRequest {
-    pub id: u64,
-    pub jsonrpc: String,
+    pub id: ProtocolRpcId,
+    pub jsonrpc: JsonRpcVersion,
     pub method: String,
     pub params: JsonRpcRequestParams,
 }
@@ -165,8 +167,8 @@ pub struct SessionUpdate {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionUpdateJsonRpc {
-    pub id: u64,
-    pub jsonrpc: String,
+    pub id: ProtocolRpcId,
+    pub jsonrpc: JsonRpcVersion,
     pub method: String,
     pub params: SessionUpdate,
 }
@@ -174,8 +176,8 @@ pub struct SessionUpdateJsonRpc {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SimpleJsonRpcBoolResponse {
-    pub id: u64,
-    pub jsonrpc: String,
+    pub id: ProtocolRpcId,
+    pub jsonrpc: JsonRpcVersion,
     pub result: bool,
 }
 
@@ -219,8 +221,8 @@ pub struct Redirect {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionRequestJsonRpc {
-    pub id: u64,
-    pub jsonrpc: String,
+    pub id: ProtocolRpcId,
+    pub jsonrpc: JsonRpcVersion,
     pub method: String,
     pub params: SessionRequest,
 }
@@ -243,31 +245,24 @@ pub struct SessionRequestRequest {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionRequestJsonRpcResultResponse {
-    pub id: u64,
-    pub jsonrpc: String,
+    pub id: ProtocolRpcId,
+    pub jsonrpc: JsonRpcVersion,
     pub result: serde_json::Value,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SessionRequestJsonRpcErrorResponse {
-    pub id: u64,
-    pub jsonrpc: String,
-    pub error: serde_json::Value,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SessionRequestJsonRpcResponse {
     Result(SessionRequestJsonRpcResultResponse),
-    Error(SessionRequestJsonRpcErrorResponse),
+    Error(GenericJsonRpcResponseError),
 }
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi_macros::Record))]
 pub struct SessionDeleteJsonRpc {
-    pub id: u64,
-    pub jsonrpc: String,
+    pub id: ProtocolRpcId,
+    pub jsonrpc: JsonRpcVersion,
     pub method: String,
     pub params: SessionDelete,
 }
@@ -289,8 +284,8 @@ pub struct SessionExtend {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionExtendJsonRpc {
-    pub id: u64,
-    pub jsonrpc: String,
+    pub id: ProtocolRpcId,
+    pub jsonrpc: JsonRpcVersion,
     pub method: String,
     pub params: SessionExtend,
 }
@@ -312,8 +307,8 @@ pub struct EventParams {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionEventJsonRpc {
-    pub id: u64,
-    pub jsonrpc: String,
+    pub id: ProtocolRpcId,
+    pub jsonrpc: JsonRpcVersion,
     pub method: String,
     pub params: EventParams,
 }
@@ -328,8 +323,8 @@ pub enum GenericJsonRpcMessage {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GenericJsonRpcRequest {
-    pub id: MessageId,
-    pub jsonrpc: String,
+    pub id: ProtocolRpcId,
+    pub jsonrpc: JsonRpcVersion,
     pub method: String,
     pub params: serde_json::Value,
 }
@@ -344,17 +339,26 @@ pub enum GenericJsonRpcResponse {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GenericJsonRpcResponseSuccess {
-    pub id: MessageId,
-    pub jsonrpc: String,
+    pub id: ProtocolRpcId,
+    pub jsonrpc: JsonRpcVersion,
     pub result: serde_json::Value,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GenericJsonRpcResponseError {
-    pub id: MessageId,
-    pub jsonrpc: String,
-    pub error: serde_json::Value,
+    pub id: ProtocolRpcId,
+    pub jsonrpc: JsonRpcVersion,
+    pub error: GenericJsonRpcResponseErrorData,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GenericJsonRpcResponseErrorData {
+    pub code: i32,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<String>,
 }
 
 #[cfg(test)]

--- a/crates/yttrium/src/sign/protocol_types/rpc_id.rs
+++ b/crates/yttrium/src/sign/protocol_types/rpc_id.rs
@@ -1,0 +1,40 @@
+use {
+    rand::Rng,
+    serde::{Deserialize, Serialize},
+    std::fmt::Display,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ProtocolRpcId(pub(self) u64);
+
+impl ProtocolRpcId {
+    pub fn generate() -> ProtocolRpcId {
+        // overflows u64 at year 10889
+        // overflows Number.MAX_SAFE_INTEGER at year 3084
+        let time = crate::time::SystemTime::now()
+            .duration_since(crate::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+        let mut rng = rand::thread_rng();
+        let random = rng.gen_range(0..=u8::MAX) as u64;
+        let id = (time << 8) | random;
+        Self(id)
+    }
+
+    pub fn into_value(self) -> u64 {
+        self.0
+    }
+}
+
+impl Display for ProtocolRpcId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(feature = "uniffi")]
+uniffi::custom_type!(ProtocolRpcId, u64, {
+    remote,
+    try_lift: |val| Ok(ProtocolRpcId(val)),
+    lower: |obj| obj.into_value(),
+});

--- a/crates/yttrium/src/sign/relay.rs
+++ b/crates/yttrium/src/sign/relay.rs
@@ -6,7 +6,8 @@ use {
             incoming::HandleError,
             priority_future::PriorityReceiver,
             protocol_types::{
-                SessionRequestJsonRpc, SessionRequestJsonRpcResponse,
+                ProtocolRpcId, SessionRequestJsonRpc,
+                SessionRequestJsonRpcResponse,
             },
             relay_url::ConnectionOptions,
             storage::Storage,
@@ -831,13 +832,17 @@ impl std::fmt::Debug for ConnectionState {
 #[derive(Debug)]
 pub enum IncomingSessionMessage {
     SessionRequest(SessionRequestJsonRpc, VerifyContext),
-    Disconnect(u64, Topic),
+    Disconnect(ProtocolRpcId, Topic),
     SessionEvent(Topic, String, serde_json::Value, String),
-    SessionUpdate(u64, Topic, crate::sign::protocol_types::SettleNamespaces),
-    SessionExtend(u64, Topic),
-    SessionConnect(u64, Topic),
-    SessionReject(u64, Topic),
-    SessionRequestResponse(u64, Topic, SessionRequestJsonRpcResponse),
+    SessionUpdate(
+        ProtocolRpcId,
+        Topic,
+        crate::sign::protocol_types::SettleNamespaces,
+    ),
+    SessionExtend(ProtocolRpcId, Topic),
+    SessionConnect(ProtocolRpcId, Topic),
+    SessionReject(ProtocolRpcId, Topic),
+    SessionRequestResponse(ProtocolRpcId, Topic, SessionRequestJsonRpcResponse),
 }
 
 // MaybeVerifiedRequest is now defined in client.rs and imported via the parent module

--- a/crates/yttrium/src/sign/storage.rs
+++ b/crates/yttrium/src/sign/storage.rs
@@ -1,6 +1,9 @@
 pub use jsonwebtoken::jwk::Jwk;
 use {
-    crate::sign::client_types::{Session, TransportType},
+    crate::sign::{
+        client_types::{Session, TransportType},
+        protocol_types::ProtocolRpcId,
+    },
     relay_rpc::domain::Topic,
     serde::{Deserialize, Serialize},
 };
@@ -27,14 +30,14 @@ pub trait Storage: Send + Sync {
     fn save_pairing(
         &self,
         topic: Topic,
-        rpc_id: u64,
+        rpc_id: ProtocolRpcId,
         sym_key: [u8; 32],
         self_key: [u8; 32],
     ) -> Result<(), StorageError>;
     fn get_pairing(
         &self,
         topic: Topic,
-        rpc_id: u64,
+        rpc_id: ProtocolRpcId,
     ) -> Result<Option<StoragePairing>, StorageError>;
     fn save_partial_session(
         &self,
@@ -47,8 +50,8 @@ pub trait Storage: Send + Sync {
     // JSON-RPC History
     fn insert_json_rpc_history(
         &self,
-        request_id: u64,
-        topic: String,
+        request_id: ProtocolRpcId,
+        topic: Topic,
         method: String,
         body: String,
         transport_type: Option<TransportType>,
@@ -56,18 +59,18 @@ pub trait Storage: Send + Sync {
 
     fn update_json_rpc_history_response(
         &self,
-        request_id: u64,
+        request_id: ProtocolRpcId,
         response: String,
     ) -> Result<(), StorageError>;
 
     fn delete_json_rpc_history_by_topic(
         &self,
-        topic: String,
+        topic: Topic,
     ) -> Result<(), StorageError>;
 
     fn does_json_rpc_exist(
         &self,
-        request_id: u64,
+        request_id: ProtocolRpcId,
     ) -> Result<bool, StorageError>;
 }
 

--- a/crates/yttrium/src/sign/utils.rs
+++ b/crates/yttrium/src/sign/utils.rs
@@ -30,7 +30,6 @@ use {
     },
     chacha20poly1305::{aead::Aead, AeadCore, ChaCha20Poly1305, KeyInit},
     data_encoding::BASE64,
-    rand::Rng,
     relay_rpc::domain::Topic,
     serde::Serialize,
     sha2::{Digest, Sha256},
@@ -50,17 +49,6 @@ pub fn diffie_hellman(
     let mut expanded_key = [0u8; 32];
     derived_key.expand(b"", &mut expanded_key).unwrap();
     expanded_key
-}
-
-pub fn generate_rpc_id() -> u64 {
-    let time = crate::time::SystemTime::now()
-        .duration_since(crate::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs()
-        * 1_000_000;
-    let mut rng = rand::thread_rng();
-    let random = rng.gen_range(0..=u16::MAX);
-    time + random as u64
 }
 
 pub fn is_expired(expiry: u64) -> bool {

--- a/crates/yttrium/src/sign/verify/validate.rs
+++ b/crates/yttrium/src/sign/verify/validate.rs
@@ -445,6 +445,7 @@ mod tests {
         super::*,
         crate::sign::{
             client_types::{Session, TransportType},
+            protocol_types::ProtocolRpcId,
             storage::StoragePairing,
         },
         relay_rpc::domain::Topic,
@@ -506,7 +507,7 @@ mod tests {
             fn save_pairing(
                 &self,
                 _topic: Topic,
-                _rpc_id: u64,
+                _rpc_id: ProtocolRpcId,
                 _sym_key: [u8; 32],
                 _self_key: [u8; 32],
             ) -> Result<(), StorageError> {
@@ -515,7 +516,7 @@ mod tests {
             fn get_pairing(
                 &self,
                 _topic: Topic,
-                _rpc_id: u64,
+                _rpc_id: ProtocolRpcId,
             ) -> Result<Option<StoragePairing>, StorageError> {
                 Err(StorageError::Runtime("unimplemented".to_string()))
             }
@@ -528,8 +529,8 @@ mod tests {
             }
             fn insert_json_rpc_history(
                 &self,
-                _request_id: u64,
-                _topic: String,
+                _request_id: ProtocolRpcId,
+                _topic: Topic,
                 _method: String,
                 _body: String,
                 _transport_type: Option<TransportType>,
@@ -538,20 +539,20 @@ mod tests {
             }
             fn update_json_rpc_history_response(
                 &self,
-                _request_id: u64,
+                _request_id: ProtocolRpcId,
                 _response: String,
             ) -> Result<(), StorageError> {
                 Err(StorageError::Runtime("unimplemented".to_string()))
             }
             fn delete_json_rpc_history_by_topic(
                 &self,
-                _topic: String,
+                _topic: Topic,
             ) -> Result<(), StorageError> {
                 Err(StorageError::Runtime("unimplemented".to_string()))
             }
             fn does_json_rpc_exist(
                 &self,
-                _request_id: u64,
+                _request_id: ProtocolRpcId,
             ) -> Result<bool, StorageError> {
                 Err(StorageError::Runtime("unimplemented".to_string()))
             }
@@ -621,7 +622,7 @@ mod tests {
             fn save_pairing(
                 &self,
                 _topic: Topic,
-                _rpc_id: u64,
+                _rpc_id: ProtocolRpcId,
                 _sym_key: [u8; 32],
                 _self_key: [u8; 32],
             ) -> Result<(), StorageError> {
@@ -630,7 +631,7 @@ mod tests {
             fn get_pairing(
                 &self,
                 _topic: Topic,
-                _rpc_id: u64,
+                _rpc_id: ProtocolRpcId,
             ) -> Result<Option<StoragePairing>, StorageError> {
                 Err(StorageError::Runtime("unimplemented".to_string()))
             }
@@ -643,8 +644,8 @@ mod tests {
             }
             fn insert_json_rpc_history(
                 &self,
-                _request_id: u64,
-                _topic: String,
+                _request_id: ProtocolRpcId,
+                _topic: Topic,
                 _method: String,
                 _body: String,
                 _transport_type: Option<TransportType>,
@@ -653,20 +654,20 @@ mod tests {
             }
             fn update_json_rpc_history_response(
                 &self,
-                _request_id: u64,
+                _request_id: ProtocolRpcId,
                 _response: String,
             ) -> Result<(), StorageError> {
                 Err(StorageError::Runtime("unimplemented".to_string()))
             }
             fn delete_json_rpc_history_by_topic(
                 &self,
-                _topic: String,
+                _topic: Topic,
             ) -> Result<(), StorageError> {
                 Err(StorageError::Runtime("unimplemented".to_string()))
             }
             fn does_json_rpc_exist(
                 &self,
-                _request_id: u64,
+                _request_id: ProtocolRpcId,
             ) -> Result<bool, StorageError> {
                 Err(StorageError::Runtime("unimplemented".to_string()))
             }
@@ -739,7 +740,7 @@ mod tests {
             fn save_pairing(
                 &self,
                 _topic: Topic,
-                _rpc_id: u64,
+                _rpc_id: ProtocolRpcId,
                 _sym_key: [u8; 32],
                 _self_key: [u8; 32],
             ) -> Result<(), StorageError> {
@@ -748,7 +749,7 @@ mod tests {
             fn get_pairing(
                 &self,
                 _topic: Topic,
-                _rpc_id: u64,
+                _rpc_id: ProtocolRpcId,
             ) -> Result<Option<StoragePairing>, StorageError> {
                 Err(StorageError::Runtime("unimplemented".to_string()))
             }
@@ -761,8 +762,8 @@ mod tests {
             }
             fn insert_json_rpc_history(
                 &self,
-                _request_id: u64,
-                _topic: String,
+                _request_id: ProtocolRpcId,
+                _topic: Topic,
                 _method: String,
                 _body: String,
                 _transport_type: Option<TransportType>,
@@ -771,20 +772,20 @@ mod tests {
             }
             fn update_json_rpc_history_response(
                 &self,
-                _request_id: u64,
+                _request_id: ProtocolRpcId,
                 _response: String,
             ) -> Result<(), StorageError> {
                 Err(StorageError::Runtime("unimplemented".to_string()))
             }
             fn delete_json_rpc_history_by_topic(
                 &self,
-                _topic: String,
+                _topic: Topic,
             ) -> Result<(), StorageError> {
                 Err(StorageError::Runtime("unimplemented".to_string()))
             }
             fn does_json_rpc_exist(
                 &self,
-                _request_id: u64,
+                _request_id: ProtocolRpcId,
             ) -> Result<bool, StorageError> {
                 Err(StorageError::Runtime("unimplemented".to_string()))
             }
@@ -855,7 +856,7 @@ mod tests {
             fn save_pairing(
                 &self,
                 _topic: Topic,
-                _rpc_id: u64,
+                _rpc_id: ProtocolRpcId,
                 _sym_key: [u8; 32],
                 _self_key: [u8; 32],
             ) -> Result<(), StorageError> {
@@ -864,7 +865,7 @@ mod tests {
             fn get_pairing(
                 &self,
                 _topic: Topic,
-                _rpc_id: u64,
+                _rpc_id: ProtocolRpcId,
             ) -> Result<Option<StoragePairing>, StorageError> {
                 Err(StorageError::Runtime("unimplemented".to_string()))
             }
@@ -877,8 +878,8 @@ mod tests {
             }
             fn insert_json_rpc_history(
                 &self,
-                _request_id: u64,
-                _topic: String,
+                _request_id: ProtocolRpcId,
+                _topic: Topic,
                 _method: String,
                 _body: String,
                 _transport_type: Option<TransportType>,
@@ -887,20 +888,20 @@ mod tests {
             }
             fn update_json_rpc_history_response(
                 &self,
-                _request_id: u64,
+                _request_id: ProtocolRpcId,
                 _response: String,
             ) -> Result<(), StorageError> {
                 Err(StorageError::Runtime("unimplemented".to_string()))
             }
             fn delete_json_rpc_history_by_topic(
                 &self,
-                _topic: String,
+                _topic: Topic,
             ) -> Result<(), StorageError> {
                 Err(StorageError::Runtime("unimplemented".to_string()))
             }
             fn does_json_rpc_exist(
                 &self,
-                _request_id: u64,
+                _request_id: ProtocolRpcId,
             ) -> Result<bool, StorageError> {
                 Err(StorageError::Runtime("unimplemented".to_string()))
             }
@@ -974,7 +975,7 @@ mod tests {
             fn save_pairing(
                 &self,
                 _topic: Topic,
-                _rpc_id: u64,
+                _rpc_id: ProtocolRpcId,
                 _sym_key: [u8; 32],
                 _self_key: [u8; 32],
             ) -> Result<(), StorageError> {
@@ -983,7 +984,7 @@ mod tests {
             fn get_pairing(
                 &self,
                 _topic: Topic,
-                _rpc_id: u64,
+                _rpc_id: ProtocolRpcId,
             ) -> Result<Option<StoragePairing>, StorageError> {
                 Err(StorageError::Runtime("unimplemented".to_string()))
             }
@@ -996,8 +997,8 @@ mod tests {
             }
             fn insert_json_rpc_history(
                 &self,
-                _request_id: u64,
-                _topic: String,
+                _request_id: ProtocolRpcId,
+                _topic: Topic,
                 _method: String,
                 _body: String,
                 _transport_type: Option<TransportType>,
@@ -1006,20 +1007,20 @@ mod tests {
             }
             fn update_json_rpc_history_response(
                 &self,
-                _request_id: u64,
+                _request_id: ProtocolRpcId,
                 _response: String,
             ) -> Result<(), StorageError> {
                 Err(StorageError::Runtime("unimplemented".to_string()))
             }
             fn delete_json_rpc_history_by_topic(
                 &self,
-                _topic: String,
+                _topic: Topic,
             ) -> Result<(), StorageError> {
                 Err(StorageError::Runtime("unimplemented".to_string()))
             }
             fn does_json_rpc_exist(
                 &self,
-                _request_id: u64,
+                _request_id: ProtocolRpcId,
             ) -> Result<bool, StorageError> {
                 Err(StorageError::Runtime("unimplemented".to_string()))
             }

--- a/crates/yttrium/src/uniffi_compat/sign/ffi_types.rs
+++ b/crates/yttrium/src/uniffi_compat/sign/ffi_types.rs
@@ -1,7 +1,10 @@
 use {
     crate::sign::{
         client_types::TransportType,
-        protocol_types::{Metadata, ProposalNamespaces, SettleNamespace},
+        protocol_types::{
+            JsonRpcVersion, Metadata, ProposalNamespaces, ProtocolRpcId,
+            SettleNamespace,
+        },
     },
     relay_rpc::domain::Topic,
     serde::{Deserialize, Serialize},
@@ -11,7 +14,7 @@ use {
 #[derive(uniffi_macros::Record, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionProposalFfi {
-    pub id: String,
+    pub id: ProtocolRpcId,
     pub topic: String,
     pub pairing_sym_key: Vec<u8>,
     pub proposer_public_key: Vec<u8>,
@@ -46,22 +49,22 @@ pub struct SessionRequestFfi {
 
 #[derive(uniffi_macros::Record, Serialize, Deserialize)]
 pub struct SessionRequestJsonRpcFfi {
-    pub id: u64,
+    pub id: ProtocolRpcId,
     pub method: String,
     pub params: SessionRequestFfi,
 }
 
 #[derive(uniffi_macros::Record, Debug, Serialize, Deserialize)]
 pub struct SessionRequestJsonRpcResultResponseFfi {
-    pub id: u64,
-    pub jsonrpc: String,
+    pub id: ProtocolRpcId,
+    pub jsonrpc: JsonRpcVersion,
     pub result: String, // JSON string instead of serde_json::Value
 }
 
 #[derive(uniffi_macros::Record, Debug, Serialize, Deserialize)]
 pub struct SessionRequestJsonRpcErrorResponseFfi {
-    pub id: u64,
-    pub jsonrpc: String,
+    pub id: ProtocolRpcId,
+    pub jsonrpc: JsonRpcVersion,
     pub error: String, // JSON string instead of serde_json::Value
 }
 
@@ -75,7 +78,7 @@ pub enum SessionRequestJsonRpcResponseFfi {
 #[derive(uniffi_macros::Record, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionFfi {
-    pub request_id: u64,
+    pub request_id: ProtocolRpcId,
     pub session_sym_key: Vec<u8>,
     pub self_public_key: Vec<u8>,
     pub topic: Topic,


### PR DESCRIPTION
- Addressing this [error](https://reown-inc.slack.com/archives/C058RS0MH38/p1762311772290049)
- Implementing better unique RPC IDs
- Refactoring to use consistent `ProtocolRpcId` and `Topic` types instead of strings or integers
- Add `JsonRpcVersion` type which works around https://github.com/mozilla/uniffi-rs/issues/2727 and slightly improves code clarity
- Upgrades to UniFFI v0.30.0

So error is client received duplicate RPC ID (encrypted) and ignored it, resulting in a timeout. I suspect this is because my generate_rpc_id function was using unix seconds + random 16 bits instead of random milliseconds + 16 bits. If my math checks out, running this code once a minute and assuming it completes within 1 second (which it pretty much does) then we'd see a collision every 45 days. Can't have that. My PR here fixes this by switching to ms timestamps.

With the [previous algorithm](https://github.com/WalletConnect/walletconnect-utils/blob/873e5d3bf07d7c6b787e056340f7451f9b1c0451/jsonrpc/utils/src/format.ts#L23) it multiplied the random value by 1 thousand which prevents operation past year 2255. I switching to a bit-shift approach which gives us until year 3084.

Remaining work:
- [x] How to handle JS BigInt IDs? (strings ending in `n`)
  - update: not an issue
- [x] Does Kotlin support storing string RPC IDs?
  - update: not an issue