### PR TITLE
Removing arm64 exclusions from podspec for Utils

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,8 +22,8 @@ let yttriumUtilsXcframeworkTarget: Target = useLocalRustXcframework ?
     ) :
     .binaryTarget(
         name: "YttriumUtilsXCFramework",
-        url: "https://github.com/reown-com/yttrium/releases/download/0.9.78/libyttrium-utils.xcframework.zip",
-        checksum: "e38a7c06b7132c35c86b1efb81cb36e8eb4040dc21555885c030514a4f44a911"
+        url: "https://github.com/reown-com/yttrium/releases/download/0.9.80/libyttrium-utils.xcframework.zip",
+        checksum: "b8b08dfe910a6589bb47c43ab5cb8e506d0f2ca841f602853706c18c9e1af445"
     )
 
 let package = Package(

--- a/YttriumUtilsWrapper.podspec
+++ b/YttriumUtilsWrapper.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "YttriumUtilsWrapper"
-  spec.version      = "0.9.78"
+  spec.version      = "0.9.80"
   spec.summary      = "Yttrium Utils - Multi-blockchain utilities for EIP155, Stacks, and Chain Abstraction"
   spec.description  = <<-DESC
                    Yttrium Utils provides multi-blockchain utilities including EIP155 support, Stacks integration, 
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
 
   # Binary pod via :http to avoid running heavy prepare_command on trunk
   # Binary asset hosted on GitHub Releases; CI updates the version
-  spec.source       = { :http => "https://github.com/reown-com/yttrium/releases/download/0.9.78/libyttrium-utils-pod.zip" }
+  spec.source       = { :http => "https://github.com/reown-com/yttrium/releases/download/0.9.80/libyttrium-utils-pod.zip" }
 
   # The zip contains libyttrium-utils.xcframework at root and Sources/YttriumUtils/*.swift
   spec.vendored_frameworks = "libyttrium-utils.xcframework"


### PR DESCRIPTION
## Fix: Remove arm64 exclusion from YttriumUtilsWrapper podspec

### Problem
Flutter/Xcode builds failed with "unsupported Swift architecture" when using `YttriumUtilsWrapper` on simulators. The podspec excluded `arm64` for simulators, while the xcframework includes `arm64` simulator slices.

### Solution
Removed the `EXCLUDED_ARCHS` configuration from `YttriumUtilsWrapper.podspec` that excluded `arm64` for iOS simulators.

### Changes
- **File:** `YttriumUtilsWrapper.podspec`
- **Removed:** `EXCLUDED_ARCHS[sdk=iphonesimulator*] => 'arm64'` from both `user_target_xcconfig` and `pod_target_xcconfig`

### Result
Both `YttriumWrapper` and `YttriumUtilsWrapper` now work on:
- Physical iPhones (arm64)
- Simulators on Intel Macs (x86_64)
- Simulators on Apple Silicon Macs (arm64)

The podspec now matches the xcframework architecture support, resolving the build error.