### PR TITLE
feat(pay-api): add gatewayUrl field to CreatePaymentResponse

### DIFF
--- a/crates/pay-api/docs/create_payment.md
+++ b/crates/pay-api/docs/create_payment.md
@@ -38,6 +38,7 @@ Creates a new payment intent.
 | `amount.value` | string | Amount in minor units. |
 | `expiresAt` | number | Unix timestamp (seconds) when the payment expires. |
 | `pollInMs` | number | Recommended polling interval in milliseconds. |
+| `gatewayUrl` | string | URL for the payment gateway endpoint to process this payment. |
 
 ### Example Response
 
@@ -50,7 +51,8 @@ Creates a new payment intent.
     "value": "1000"
   },
   "expiresAt": 1733126400,
-  "pollInMs": 1000
+  "pollInMs": 1000,
+  "gatewayUrl": "https://pay.walletconnect.com/v1/gateway"
 }
 ```
 

--- a/crates/pay-api/src/bodies/create_payment.rs
+++ b/crates/pay-api/src/bodies/create_payment.rs
@@ -25,4 +25,5 @@ pub struct CreatePaymentResponse {
     pub amount: Amount,
     pub expires_at: u64,
     pub poll_in_ms: u64,
+    pub gateway_url: String,
 }


### PR DESCRIPTION
## Summary
- Adds `gateway_url: String` field to `CreatePaymentResponse` struct
- Updates API documentation with new field description and example

## Test plan
- [x] `cargo check -p pay-api` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)