### PR TITLE
Change SdkConfig into String on json client

### DIFF
--- a/crates/pay-api/src/tests.rs
+++ b/crates/pay-api/src/tests.rs
@@ -63,7 +63,6 @@ fn test_create_payment_response_success() {
         data: CreatePaymentResponse {
             payment_id: "pay_123".to_string(),
             status: "requires_action".to_string(),
-            gateway_url: "https://walletconnect.com/pay".to_string(),
             amount: Amount {
                 unit: "iso4217/USD".to_string(),
                 value: "1000".to_string(),


### PR DESCRIPTION
Addressing comments on @ganchoradkov's PR: https://github.com/reown-com/yttrium/pull/299#discussion_r2627274789

How to initialize from Kotlin with this approach:

```
fun initialize(params: Any?, result: MethodChannel.Result) {
    val dict = params as? Map<*, *> ?: return result.error("WalletConnectPay", "Invalid parameters", null)
    val baseUrl = dict["baseUrl"] as? String ?: return result.error("WalletConnectPay", "Missing baseUrl", null)
    val sdkConfig = dict["sdkConfig"] as? String ?: return result.error("WalletConnectPay", "Missing sdkConfig", null)

    walletConnectPayClient = WalletConnectPayJson(baseUrl, sdkConfig)
    result.success(true)
}
```