### PR TITLE
chore: Optimize Android .so file sizes for wcpay module

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,16 @@
 # https://docs.rs/getrandom/latest/getrandom/#webassembly-support
 [target.wasm32-unknown-unknown]
 rustflags = '--cfg getrandom_backend="wasm_js"'
+
+# Android-specific link-time optimizations for size reduction
+# These flags help reduce binary size by removing dead code
+# Note: We don't use -Wl,--strip-all here as we manually strip with llvm-strip --strip-all after build
+# to preserve UniFFI bindings during the build process
+[target.aarch64-linux-android]
+rustflags = ["-C", "link-arg=-Wl,--gc-sections"]
+
+[target.armv7-linux-androideabi]
+rustflags = ["-C", "link-arg=-Wl,--gc-sections"]
+
+[target.x86_64-linux-android]
+rustflags = ["-C", "link-arg=-Wl,--gc-sections"]

--- a/.github/workflows/release-kotlin-wcpay.yml
+++ b/.github/workflows/release-kotlin-wcpay.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build Rust library (wcpay feature set)
         run: |
           cargo ndk -t ${{ matrix.target }} build \
-            --profile=uniffi-release-kotlin \
+            --profile=uniffi-release-kotlin-wcpay \
             --no-default-features \
             --features=android,pay,uniffi/cli
       - name: Generate Kotlin wcpay bindings (once, on aarch64 only)
@@ -55,7 +55,7 @@ jobs:
             --features=android,pay,uniffi/cli \
             -p kotlin-ffi \
             --bin uniffi-bindgen generate \
-            --library target/${{ matrix.target }}/uniffi-release-kotlin/libuniffi_yttrium.so \
+            --library target/${{ matrix.target }}/uniffi-release-kotlin-wcpay/libuniffi_yttrium.so \
             --language kotlin \
             --out-dir yttrium/kotlin-wcpay-bindings
           
@@ -77,7 +77,7 @@ jobs:
             NDK_PATH="$ANDROID_HOME/ndk/$LATEST_NDK"
             if [ -f "$NDK_PATH/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip" ]; then
                 echo "Found llvm-strip at: $NDK_PATH/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip"
-                $NDK_PATH/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip target/${{ matrix.target }}/uniffi-release-kotlin/libuniffi_yttrium.so
+                $NDK_PATH/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all target/${{ matrix.target }}/uniffi-release-kotlin-wcpay/libuniffi_yttrium.so
             else
                 echo "Warning: Could not find llvm-strip, skipping strip step"
                 echo "Available NDK versions:"
@@ -100,7 +100,7 @@ jobs:
           fi
 
           mkdir -p yttrium/libs/$abi_name
-          cp target/${{ matrix.target }}/uniffi-release-kotlin/libuniffi_yttrium.so yttrium/libs/$abi_name/libuniffi_yttrium_wcpay.so
+          cp target/${{ matrix.target }}/uniffi-release-kotlin-wcpay/libuniffi_yttrium.so yttrium/libs/$abi_name/libuniffi_yttrium_wcpay.so
 
       - name: Upload artifact (unique name per target)
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ Utilities/InstalledSwiftPMConfiguration/config.json
 /kotlin-bindings
 /yttrium/kotlin-bindings
 /yttrium/kotlin-utils-bindings
+/yttrium/kotlin-wcpay-bindings
 .gradle
 /crates/kotlin-ffi/android/build
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,6 +155,9 @@ inherits = "profile8"
 [profile.uniffi-release-kotlin]
 inherits = "profile11"
 
+[profile.uniffi-release-kotlin-wcpay]
+inherits = "profile11-wcpay"
+
 [profile.uniffi-release-swift]
 inherits = "profile9"
 
@@ -266,6 +269,14 @@ opt-level = "z"
 codegen-units = 1
 lto = true
 panic = "abort"
+
+[profile.profile11-wcpay]
+inherits = "profile11"
+# Additional optimizations for wcpay variant
+# Explicitly disable debug symbols for maximum size reduction
+debug = false
+# Note: strip = true is not set here as it removes UniFFI bindings
+# Manual stripping with llvm-strip --strip-all is performed after build
 
 [profile.profile10-nostrip]
 inherits = "profile10"

--- a/crates/kotlin-ffi/android/proguard-rules-wcpay.pro
+++ b/crates/kotlin-ffi/android/proguard-rules-wcpay.pro
@@ -1,0 +1,30 @@
+# WCPay-specific ProGuard rules
+# These rules are in addition to the base proguard-rules.pro
+
+# Keep generated uniffi bindings for wcpay
+-keep class uniffi.uniffi_yttrium_wcpay.** { *; }
+-keep class uniffi.yttrium_wcpay.** { *; }
+
+# Preserve all classes that interact with JNI for wcpay
+-keepclasseswithmembers class * {
+    native <methods>;
+}
+
+# Preserve all Rust FFI bindings for wcpay
+-keep class com.reown.yttrium.wcpay.** { *; }
+-keep class com.yttrium.wcpay.** { *; }
+
+# Preserve all org.rustls.platformverifier classes (used by wcpay)
+-keep, includedescriptorclasses class org.rustls.platformverifier.** { *; }
+
+# Optimize: Remove logging calls in release builds
+-assumenosideeffects class android.util.Log {
+    public static *** d(...);
+    public static *** v(...);
+    public static *** i(...);
+}
+
+# Keep native method registration
+-keepclasseswithmembernames class * {
+    native <methods>;
+}

--- a/generate_kotlin_locally.sh
+++ b/generate_kotlin_locally.sh
@@ -18,6 +18,7 @@ ACCOUNT_FEATURES="android,erc6492_client,pay,uniffi/cli"
 UTILS_FEATURES="android,chain_abstraction_client,solana,stacks,sui,ton,eip155,uniffi/cli"
 WCPAY_FEATURES="android,pay,uniffi/cli"
 PROFILE="uniffi-release-kotlin"
+WCPAY_PROFILE="uniffi-release-kotlin-wcpay"
 OUTPUT_ROOT="build/kotlin-artifacts"
 GEN_ROOT="crates/kotlin-ffi/android/build/generated"
 TARGETS=("aarch64-linux-android" "armv7-linux-androideabi" "x86_64-linux-android")
@@ -95,8 +96,8 @@ copy_library_variants() {
             fi
             
             if [ -n "$strip_bin" ]; then
-                echo "Stripping $src with $strip_bin"
-                "$strip_bin" "$src"
+                echo "Stripping $src with $strip_bin --strip-all"
+                "$strip_bin" --strip-all "$src"
             fi
         fi
         
@@ -114,6 +115,7 @@ install_variant_sources() {
     local wrapper_base="$GEN_ROOT/${variant}/kotlin/com/yttrium"
     local library_name="libuniffi_yttrium.so"
     local system_library="uniffi_yttrium"
+    local profile_to_use="$PROFILE"
 
     if [ "$variant" = "utils" ]; then
         library_name="libuniffi_yttrium_utils.so"
@@ -121,6 +123,7 @@ install_variant_sources() {
     elif [ "$variant" = "wcpay" ]; then
         library_name="libuniffi_yttrium_wcpay.so"
         system_library="uniffi_yttrium_wcpay"
+        profile_to_use="$WCPAY_PROFILE"
     fi
 
     rm -rf "$jni_base" "$kotlin_base" "$wrapper_base"
@@ -128,7 +131,7 @@ install_variant_sources() {
     for target in "${TARGETS[@]}"; do
         local abi
         abi="$(abi_name "$target")"
-        local src="target/${target}/${PROFILE}/libuniffi_yttrium.so"
+        local src="target/${target}/${profile_to_use}/libuniffi_yttrium.so"
         mkdir -p "$jni_base/${abi}"
         cp "$src" "$jni_base/${abi}/${library_name}"
     done
@@ -265,10 +268,10 @@ build_utils_variant() {
         abi="$(abi_name "$target")"
         local src="target/${target}/${PROFILE}/libuniffi_yttrium.so"
         
-        # Strip the binary before copying
+        # Strip the binary before copying (use --strip-all for maximum size reduction)
         if [ -n "$strip_bin" ]; then
-            echo "Stripping $src with $strip_bin"
-            "$strip_bin" "$src"
+            echo "Stripping $src with $strip_bin --strip-all"
+            "$strip_bin" --strip-all "$src"
         fi
         
         mkdir -p "$OUTPUT_ROOT/libs/${abi}"
@@ -280,9 +283,9 @@ build_utils_variant() {
 }
 
 build_wcpay_variant() {
-    echo "Building wcpay variant (pay only)..."
+    echo "Building wcpay variant (pay only) with optimized profile..."
     cargo ndk -t armv7-linux-androideabi -t aarch64-linux-android -t x86_64-linux-android build \
-        --profile="$PROFILE" \
+        --profile="$WCPAY_PROFILE" \
         --no-default-features \
         --features="$WCPAY_FEATURES" \
         -p kotlin-ffi
@@ -292,7 +295,7 @@ build_wcpay_variant() {
         --features="$WCPAY_FEATURES" \
         -p kotlin-ffi \
         --bin uniffi-bindgen generate \
-        --library "target/aarch64-linux-android/${PROFILE}/libuniffi_yttrium.so" \
+        --library "target/aarch64-linux-android/${WCPAY_PROFILE}/libuniffi_yttrium.so" \
         --language kotlin \
         --out-dir yttrium/kotlin-wcpay-bindings
 
@@ -313,12 +316,12 @@ build_wcpay_variant() {
     for target in "${TARGETS[@]}"; do
         local abi
         abi="$(abi_name "$target")"
-        local src="target/${target}/${PROFILE}/libuniffi_yttrium.so"
+        local src="target/${target}/${WCPAY_PROFILE}/libuniffi_yttrium.so"
         
-        # Strip the binary before copying
+        # Strip the binary before copying (use --strip-all for maximum size reduction)
         if [ -n "$strip_bin" ]; then
-            echo "Stripping $src with $strip_bin"
-            "$strip_bin" "$src"
+            echo "Stripping $src with $strip_bin --strip-all"
+            "$strip_bin" --strip-all "$src"
         fi
         
         mkdir -p "$OUTPUT_ROOT/libs/${abi}"
@@ -371,8 +374,9 @@ strip_binaries() {
 
     for lib in "${libs_to_strip[@]}"; do
         if [ -f "$lib" ]; then
-            # Full strip to minimize binary size (matching 0.9.55 release)
-            "$strip_bin" "$lib"
+            # Full strip to minimize binary size (use --strip-all for maximum reduction)
+            echo "Stripping $lib with --strip-all"
+            "$strip_bin" --strip-all "$lib"
         fi
     done
 }

--- a/scripts/measure-wcpay-size.sh
+++ b/scripts/measure-wcpay-size.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+set -eo pipefail
+
+# Script to measure wcpay .so file sizes and AAR size
+# Usage: ./scripts/measure-wcpay-size.sh [output-dir]
+
+OUTPUT_DIR="${1:-build/kotlin-artifacts}"
+RESULTS_FILE="${OUTPUT_DIR}/wcpay-size-report.txt"
+
+echo "=== WCPay Size Measurement Report ===" > "$RESULTS_FILE"
+echo "Generated: $(date)" >> "$RESULTS_FILE"
+echo "" >> "$RESULTS_FILE"
+
+# Function to format bytes to human-readable format
+format_size() {
+    local bytes=$1
+    if command -v numfmt >/dev/null 2>&1; then
+        numfmt --to=iec-i --suffix=B "$bytes"
+    else
+        # Fallback for systems without numfmt (macOS)
+        if [ "$bytes" -lt 1024 ]; then
+            echo "${bytes}B"
+        elif [ "$bytes" -lt 1048576 ]; then
+            echo "$((bytes / 1024))KB"
+        else
+            echo "$((bytes / 1048576))MB"
+        fi
+    fi
+}
+
+total_size=0
+abi_count=0
+
+echo "=== Native Library Sizes (.so files) ===" >> "$RESULTS_FILE"
+echo "" >> "$RESULTS_FILE"
+
+for abi in arm64-v8a armeabi-v7a x86_64; do
+    so_file="${OUTPUT_DIR}/libs/${abi}/libuniffi_yttrium_wcpay.so"
+    if [ -f "$so_file" ]; then
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            size=$(stat -f%z "$so_file")
+        else
+            size=$(stat -c%s "$so_file")
+        fi
+        formatted=$(format_size "$size")
+        echo "  ${abi}: ${formatted} (${size} bytes)" >> "$RESULTS_FILE"
+        total_size=$((total_size + size))
+        abi_count=$((abi_count + 1))
+    else
+        echo "  ${abi}: NOT FOUND" >> "$RESULTS_FILE"
+    fi
+done
+
+echo "" >> "$RESULTS_FILE"
+echo "Total .so size: $(format_size $total_size) ($total_size bytes)" >> "$RESULTS_FILE"
+echo "Number of ABIs: $abi_count" >> "$RESULTS_FILE"
+echo "" >> "$RESULTS_FILE"
+
+# Check for AAR file
+aar_file="${OUTPUT_DIR}/wcpay-release.aar"
+if [ -f "$aar_file" ]; then
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        aar_size=$(stat -f%z "$aar_file")
+    else
+        aar_size=$(stat -c%s "$aar_file")
+    fi
+    echo "=== AAR Size ===" >> "$RESULTS_FILE"
+    echo "  AAR: $(format_size $aar_size) ($aar_size bytes)" >> "$RESULTS_FILE"
+    echo "" >> "$RESULTS_FILE"
+fi
+
+# Check Gradle build output
+gradle_aar="crates/kotlin-ffi/android/build/outputs/aar/wcpay-release.aar"
+if [ -f "$gradle_aar" ]; then
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        gradle_size=$(stat -f%z "$gradle_aar")
+    else
+        gradle_size=$(stat -c%s "$gradle_aar")
+    fi
+    echo "=== Gradle Build AAR Size ===" >> "$RESULTS_FILE"
+    echo "  AAR: $(format_size $gradle_size) ($gradle_size bytes)" >> "$RESULTS_FILE"
+    echo "" >> "$RESULTS_FILE"
+fi
+
+# Display results
+cat "$RESULTS_FILE"
+
+echo ""
+echo "Full report saved to: $RESULTS_FILE"


### PR DESCRIPTION
## Summary
     2 │  Implements Phase 1 and Phase 2 optimizations to reduce Android .so file sizes for the wcpay module.
     3 │
     4 │  ## Changes
     5 │  - Enhanced stripping with `--strip-all` flag (5-15% reduction)
     6 │  - Optimized Rust profile with `debug=false` (5-10% reduction)
     7 │  - Link-time optimizations with `--gc-sections` (5-10% reduction)
     8 │  - Size measurement script for tracking improvements
     9 │
    10 │  ## Expected Impact
    11 │  - Total expected reduction: 20-35% in .so file sizes
    12 │  - Current measured sizes:
    13 │    - arm64-v8a: 5MB
    14 │    - armeabi-v7a: 4MB
    15 │    - x86_64: 6MB
    16 │
    17 │  ## Testing
    18 │  - ✅ Build completed successfully
    19 │  - ✅ All variants (yttrium, utils, wcpay) build correctly
    20 │  - ✅ Size measurement script working
    21 │
    22 │  ## Future Work
    23 │  - ProGuard minification (prepared but disabled for initial testing)
    24 │  - Dependency analysis with cargo-bloat
    25 │  - Further profile optimizations
