### PR TITLE
Improve WalletConnectPay error messages for native clients

### DIFF
--- a/crates/yttrium/src/pay/mod.rs
+++ b/crates/yttrium/src/pay/mod.rs
@@ -52,9 +52,9 @@ impl From<progenitor_client::Error<types::ErrorResponse>> for PayError {
             progenitor_client::Error::InvalidResponsePayload(_, err) => {
                 Self::Api(format!("Invalid response: {}", err))
             }
-            progenitor_client::Error::UnexpectedResponse(resp) => {
-                Self::Api(format!("{}: Unexpected response", resp.status().as_u16()))
-            }
+            progenitor_client::Error::UnexpectedResponse(resp) => Self::Api(
+                format!("{}: Unexpected response", resp.status().as_u16()),
+            ),
             other => Self::Api(other.to_string()),
         }
     }


### PR DESCRIPTION
## Summary

- Extract clean error messages from API responses instead of using verbose debug format
- Previously errors showed full debug representation including HTTP headers and raw response bodies
- Now errors show just the meaningful message from the API response

## Changes

- `map_payment_options_error`: Extract `message` field from `ErrorResponse` instead of debug format
- `map_confirm_payment_error`: Same improvement for confirm payment errors  
- `PayError::From` impl: Provide cleaner fallback messages for different error types

## Before/After

**Before:**
```
Error Response: status: 401 Unauthorized; headers: {"date": "...", "content-type": "application/json", ...}; value: ErrorResponse { code: InvalidApiKey, message: "Invalid API key" }
```

**After:**
```
Invalid API key
```

## Test plan

- [x] All existing pay module tests pass
- [x] Code compiles with `pay` and `uniffi` features
- [ ] Manual testing with native client to verify error messages are cleaner

🤖 Generated with [Claude Code](https://claude.ai/code)