### PR TITLE
fix(pay): remove default 5m polling timeout

### DIFF
--- a/crates/yttrium/src/pay/mod.rs
+++ b/crates/yttrium/src/pay/mod.rs
@@ -325,7 +325,6 @@ const INITIAL_BACKOFF_MS: u64 = 1000;
 const MAX_BACKOFF_MS: u64 = 2000;
 const API_CONNECT_TIMEOUT_SECS: u64 = 10;
 const API_REQUEST_TIMEOUT_SECS: u64 = 30;
-const MAX_POLLING_DURATION_SECS: u64 = 300;
 const WCP_VERSION_HEADER: &str = "WCP-Version";
 const WCP_VERSION: &str = "2026-02-19.preview";
 
@@ -1177,15 +1176,13 @@ impl WalletConnectPay {
         );
         let poll_timeout = max_poll_ms
             .filter(|&ms| ms > 0)
-            .map(|ms| crate::time::Duration::from_millis(ms as u64))
-            .unwrap_or(crate::time::Duration::from_secs(
-                MAX_POLLING_DURATION_SECS,
-            ));
+            .map(|ms| crate::time::Duration::from_millis(ms as u64));
         let poll_start = crate::time::Instant::now();
         while !result.is_final {
-            if poll_start.elapsed() >= poll_timeout {
-                let msg =
-                    format!("polling exceeded {}ms", poll_timeout.as_millis());
+            if let Some(timeout) = poll_timeout
+                && poll_start.elapsed() >= timeout
+            {
+                let msg = format!("polling exceeded {}ms", timeout.as_millis());
                 pay_error!("confirm_payment: {}", msg);
                 let err = ConfirmPaymentError::PollingTimeout(msg);
                 self.report_error(&err, &payment_id);


### PR DESCRIPTION
## Summary
- Removes the hardcoded `MAX_POLLING_DURATION_SECS = 300` (5 minute) default polling timeout in `confirm_payment`
- When `max_poll_ms` is not provided, the SDK now polls indefinitely until the server returns a final status
- Callers can still pass `max_poll_ms` to set an explicit client-side timeout (returns `PollingTimeout` error on expiry)

## Motivation
The 5-minute default is too restrictive for slow-settling chains like BTC. Since the server already enforces payment/route/quote expiry via HTTP status codes (410, 409, `quote_expired`), the client-side default timeout is redundant and limiting — supporting BTC would otherwise require an SDK upgrade.

## Test plan
- [x] `just lint` passes
- [x] All 84 pay unit tests pass (`cargo test --features=full --lib --bins pay`)
- [x] `test_confirm_payment_polling_timeout` still validates explicit `max_poll_ms` timeout behavior
- [x] `test_confirm_payment_polls_until_final` still validates successful polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)