### PR TITLE
feat(solana): expose solana_signTransaction via UniFFI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +160,17 @@ name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
+name = "allo-isolate"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449e356a4864c017286dbbec0e12767ea07efba29e3b7d984194c2a7ff3c4550"
+dependencies = [
+ "anyhow",
+ "atomic",
+ "backtrace",
+]
 
 [[package]]
 name = "alloc-no-stdlib"
@@ -961,6 +981,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "android_log-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
+
+[[package]]
+name = "android_logger"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c494134f746c14dc653a35a4ea5aca24ac368529da5370ecf41fe0341c35772f"
+dependencies = [
+ "android_log-sys",
+ "env_logger",
+ "log",
+ "once_cell",
 ]
 
 [[package]]
@@ -1848,6 +1886,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2404,6 +2448,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base-x"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2936,6 +2995,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "build-target"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "832133bbabbbaa9fbdba793456a2827627a7d2b8fb96032fa1e7666d7895832b"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3034,6 +3099,9 @@ name = "camino"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "caps"
@@ -3045,12 +3113,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "cargo_toml"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fbd1fe9db3ebf71b89060adaf7b0504c2d6a425cf061313099547e382c2e472"
+dependencies = [
+ "serde",
+ "toml 0.8.23",
+]
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
  "cipher 0.4.4",
+]
+
+[[package]]
+name = "cbindgen"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadd868a2ce9ca38de7eeafdcec9c7065ef89b42b32f0839278d55f35c54d1ff"
+dependencies = [
+ "heck 0.4.1",
+ "indexmap 2.13.0",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.117",
+ "tempfile",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -3376,6 +3494,17 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f741c91823341bebf717d4c71bda820630ce065443b58bd1b7451af008355"
+dependencies = [
+ "is-terminal",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
+name = "colored"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
@@ -3579,6 +3708,12 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4a24b1aaf0fd0ce8b45161144d6f42cd91677fd5940fd431183eb023b3a2b8"
 
 [[package]]
 name = "convert_case"
@@ -4023,6 +4158,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dart-sys"
+version = "4.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57967e4b200d767d091b961d6ab42cc7d0cc14fe9e052e75d0d3cf9eb732d895"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "dashmap"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+dependencies = [
+ "cfg-if",
+ "num_cpus",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4072,7 +4226,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4102,6 +4256,17 @@ dependencies = [
  "schemafy",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "delegate-attr"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51aac4c99b2e6775164b412ea33ae8441b2fde2dbf05a20bc0052a63d08c475b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4664,6 +4829,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fd242f399be1da0a5354aa462d57b4ab2b4ee0683cc552f7c007d2d12d36e94"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "enum-ordinalize"
 version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4693,6 +4878,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+dependencies = [
+ "log",
+ "regex",
 ]
 
 [[package]]
@@ -4984,6 +5179,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
+name = "fern"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f0c14694cbd524c8720dd69b0e3179344f04ebb5f90f2e4a440c6ea3b2f1ee"
+dependencies = [
+ "chrono",
+ "colored 1.9.4",
+ "log",
+]
+
+[[package]]
 name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5032,6 +5238,16 @@ name = "fiat-crypto"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -5110,6 +5326,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "flutter_rust_bridge"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff1d2ad18166cead8c1b92b1c00e64aacc32e6ebd1ac95f77089c276c9c6bd8c"
+dependencies = [
+ "allo-isolate",
+ "android_logger",
+ "anyhow",
+ "build-target",
+ "bytemuck",
+ "byteorder",
+ "console_error_panic_hook",
+ "dart-sys",
+ "delegate-attr",
+ "flutter_rust_bridge_macros",
+ "futures",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "oslog 0.1.0",
+ "portable-atomic",
+ "threadpool",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "flutter_rust_bridge_codegen"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13823e8157bada9dc828d67cd23e4bcebcfffa9313175dacad0325fc3188940c"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "cargo_toml",
+ "cbindgen",
+ "chrono",
+ "clap",
+ "convert_case 0.5.0",
+ "derivative",
+ "enum-iterator",
+ "enum_dispatch",
+ "fern",
+ "glob",
+ "hex",
+ "include_dir",
+ "indicatif",
+ "indicatif-log-bridge",
+ "itertools 0.10.5",
+ "lazy_static",
+ "log",
+ "notify",
+ "notify-debouncer-mini",
+ "paste",
+ "pathdiff",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml 0.9.34+deprecated",
+ "serial_test 2.0.0",
+ "sha1",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "syn 2.0.117",
+ "tempfile",
+ "toml 0.5.11",
+ "topological-sort",
+]
+
+[[package]]
+name = "flutter_rust_bridge_macros"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36cf75fba54902e67db5eef4a520df1c9f604db6f71f106fbc012477e2d81542"
+dependencies = [
+ "hex",
+ "md-5",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5165,6 +5468,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "funty"
@@ -5427,6 +5739,12 @@ dependencies = [
  "opaque-debug",
  "polyval",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -6396,6 +6714,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6438,10 +6775,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif-log-bridge"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63703cf9069b85dbe6fe26e1c5230d013dee99d3559cd3d02ba39e099ef7ab02"
+dependencies = [
+ "indicatif",
+ "log",
+]
+
+[[package]]
 name = "inline_colorization"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1804bdb6a9784758b200007273a8b84e2b0b0b97a8f1e18e763eceb3e9f98a"
+
+[[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "inout"
@@ -6911,6 +7278,26 @@ dependencies = [
  "uniffi",
  "uniffi_build",
  "yttrium",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
 ]
 
 [[package]]
@@ -7467,6 +7854,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
@@ -7588,7 +7987,7 @@ source = "git+https://github.com/mystenlabs/sui?rev=f9c8d50#f9c8d503474a0339548f
 dependencies = [
  "anyhow",
  "bcs",
- "colored",
+ "colored 2.2.0",
  "dirs-next",
  "hex",
  "insta",
@@ -7672,7 +8071,7 @@ dependencies = [
  "bcs",
  "clap",
  "codespan",
- "colored",
+ "colored 2.2.0",
  "indexmap 2.13.0",
  "lcov",
  "move-abstract-interpreter",
@@ -8109,6 +8508,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "notify-debouncer-mini"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d40b221972a1fc5ef4d858a2f671fb34c75983eb385463dff3780eeff6a9d43"
+dependencies = [
+ "crossbeam-channel",
+ "log",
+ "notify",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8524,6 +8953,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "oslog"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8343ce955f18e7e68c0207dd0ea776ec453035685395ababd2ea651c569728b3"
+dependencies = [
+ "cc",
+ "dashmap 4.0.2",
+ "log",
+]
+
+[[package]]
+name = "oslog"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d2043d1f61d77cb2f4b1f7b7b2295f40507f5f8e9d1c8bf10a1ca5f97a3969"
+dependencies = [
+ "cc",
+ "dashmap 5.5.3",
+ "log",
 ]
 
 [[package]]
@@ -9215,7 +9666,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.8+spec-1.1.0",
 ]
 
 [[package]]
@@ -11138,6 +11589,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
@@ -11237,6 +11697,20 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap 5.5.3",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive 2.0.0",
+]
+
+[[package]]
+name = "serial_test"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
@@ -11244,7 +11718,18 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "scc",
- "serial_test_derive",
+ "serial_test_derive 3.4.0",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -11551,7 +12036,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -13945,7 +14430,7 @@ source = "git+https://github.com/mystenlabs/sui?rev=f9c8d50#f9c8d503474a0339548f
 dependencies = [
  "anyhow",
  "bcs",
- "colored",
+ "colored 2.2.0",
  "enum_dispatch",
  "fastcrypto",
  "itertools 0.13.0",
@@ -14112,7 +14597,7 @@ dependencies = [
  "base64 0.21.7",
  "bcs",
  "clap",
- "colored",
+ "colored 2.2.0",
  "fastcrypto",
  "futures",
  "futures-core",
@@ -14756,7 +15241,7 @@ checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.1.1",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -14890,13 +15375,25 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
- "serde_spanned",
+ "serde_spanned 1.1.0",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -14910,10 +15407,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
 dependencies = [
  "serde_core",
- "serde_spanned",
+ "serde_spanned 1.1.0",
  "toml_datetime 1.1.0+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.0",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -14936,6 +15442,20 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
@@ -14954,6 +15474,12 @@ checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
  "winnow 1.0.0",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -15140,6 +15666,12 @@ dependencies = [
  "prost 0.14.3",
  "tonic 0.14.5",
 ]
+
+[[package]]
+name = "topological-sort"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
 
 [[package]]
 name = "tower"
@@ -16354,6 +16886,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -16396,6 +16937,21 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -16418,6 +16974,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -16430,6 +16992,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -16439,6 +17007,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -16460,6 +17034,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -16469,6 +17049,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -16484,6 +17070,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -16493,6 +17085,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -16805,7 +17403,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen 0.6.5",
  "serde_json",
- "serial_test",
+ "serial_test 3.4.0",
  "sha2 0.11.0",
  "shared-crypto",
  "solana-client",
@@ -16849,6 +17447,31 @@ dependencies = [
  "web-sys",
  "wiremock",
  "x25519-dalek",
+]
+
+[[package]]
+name = "yttrium_dart"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "bs58 0.5.1",
+ "data-encoding",
+ "erc6492",
+ "eyre",
+ "flutter_rust_bridge",
+ "flutter_rust_bridge_codegen",
+ "log",
+ "openssl",
+ "openssl-sys",
+ "oslog 0.2.0",
+ "relay_rpc",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "solana-signer",
+ "thiserror 2.0.18",
+ "tokio",
+ "yttrium",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/kotlin-ffi", "crates/pay-api", "crates/rust-sample-wallet", "crates/yttrium"]
+members = ["crates/kotlin-ffi", "crates/pay-api", "crates/rust-sample-wallet", "crates/yttrium", "crates/yttrium_dart/rust"]
 resolver = "2"
 
 [workspace.package]

--- a/crates/yttrium/src/chain_abstraction/solana/mod.rs
+++ b/crates/yttrium/src/chain_abstraction/solana/mod.rs
@@ -27,3 +27,48 @@ pub const SOLANA_USDC_ADDRESS: &str =
 pub fn usdc_mint() -> SolanaPubkey {
     SolanaPubkey::from_str(SOLANA_USDC_ADDRESS).unwrap()
 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "uniffi", derive(uniffi_macros::Record))]
+pub struct SolanaSignedTransaction {
+    pub signature: SolanaSignature,
+    pub transaction: SolanaVersionedTransaction,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Error))]
+pub enum SolanaSignTransactionError {
+    #[error(
+        "signer pubkey {pubkey} is not a required signer of this transaction"
+    )]
+    SignerNotRequired { pubkey: String },
+}
+
+pub fn sign_versioned_transaction(
+    keypair: &SolanaKeypair,
+    mut transaction: SolanaVersionedTransaction,
+) -> Result<SolanaSignedTransaction, SolanaSignTransactionError> {
+    use solana_signer::Signer;
+    let pubkey = keypair.pubkey();
+    let num_required =
+        transaction.message.header().num_required_signatures as usize;
+    // Only the static account keys can be signers; ALT-loaded keys cannot.
+    let index = transaction
+        .message
+        .static_account_keys()
+        .iter()
+        .take(num_required)
+        .position(|k| k == &pubkey)
+        .ok_or_else(|| SolanaSignTransactionError::SignerNotRequired {
+            pubkey: pubkey.to_string(),
+        })?;
+
+    let signature = keypair.sign_message(&transaction.message.serialize());
+
+    if transaction.signatures.len() < num_required {
+        transaction.signatures.resize(num_required, SolanaSignature::default());
+    }
+    transaction.signatures[index] = signature;
+
+    Ok(SolanaSignedTransaction { signature, transaction })
+}

--- a/crates/yttrium/src/uniffi_compat/mod.rs
+++ b/crates/yttrium/src/uniffi_compat/mod.rs
@@ -46,7 +46,8 @@ use relay_rpc::domain::ProjectId;
 #[cfg(feature = "solana")]
 use {
     crate::chain_abstraction::solana::{
-        self, SolanaKeypair, SolanaPubkey, SolanaSignature,
+        self, SolanaKeypair, SolanaPubkey, SolanaSignTransactionError,
+        SolanaSignature, SolanaSignedTransaction, sign_versioned_transaction,
     },
     solana_derivation_path::DerivationPath,
     solana_sdk::bs58,
@@ -547,51 +548,6 @@ fn solana_sign_prehash(
     message: Bytes,
 ) -> SolanaSignature {
     keypair.sign_message(&message)
-}
-
-#[cfg(feature = "solana")]
-#[derive(Debug, Clone, PartialEq, Eq, uniffi::Record)]
-pub struct SolanaSignedTransaction {
-    pub signature: SolanaSignature,
-    pub transaction: VersionedTransaction,
-}
-
-#[cfg(feature = "solana")]
-#[derive(Debug, Clone, PartialEq, Eq, uniffi::Error, thiserror::Error)]
-pub enum SolanaSignTransactionError {
-    #[error(
-        "signer pubkey {pubkey} is not a required signer of this transaction"
-    )]
-    SignerNotRequired { pubkey: String },
-}
-
-#[cfg(feature = "solana")]
-fn sign_versioned_transaction(
-    keypair: &SolanaKeypair,
-    mut transaction: VersionedTransaction,
-) -> Result<SolanaSignedTransaction, SolanaSignTransactionError> {
-    let pubkey = keypair.pubkey();
-    let num_required =
-        transaction.message.header().num_required_signatures as usize;
-    // Only the static account keys can be signers; ALT-loaded keys cannot.
-    let index = transaction
-        .message
-        .static_account_keys()
-        .iter()
-        .take(num_required)
-        .position(|k| k == &pubkey)
-        .ok_or_else(|| SolanaSignTransactionError::SignerNotRequired {
-            pubkey: pubkey.to_string(),
-        })?;
-
-    let signature = keypair.sign_message(&transaction.message.serialize());
-
-    if transaction.signatures.len() < num_required {
-        transaction.signatures.resize(num_required, SolanaSignature::default());
-    }
-    transaction.signatures[index] = signature;
-
-    Ok(SolanaSignedTransaction { signature, transaction })
 }
 
 #[cfg(feature = "solana")]

--- a/crates/yttrium/src/uniffi_compat/mod.rs
+++ b/crates/yttrium/src/uniffi_compat/mod.rs
@@ -571,13 +571,15 @@ fn solana_sign_all_transactions(
         .collect()
 }
 
+// Alias of solana_sign_prehash matching the WalletConnect solana_signMessage
+// method name. Delegates to keep behavior in lockstep if signing ever changes.
 #[cfg(feature = "solana")]
 #[uniffi::export]
 fn solana_sign_message(
     keypair: SolanaKeypair,
     message: Bytes,
 ) -> SolanaSignature {
-    keypair.sign_message(&message)
+    solana_sign_prehash(keypair, message)
 }
 
 #[cfg(feature = "solana")]
@@ -775,121 +777,112 @@ mod tests {
         let n = s.parse::<U256>().unwrap();
         assert_eq!(n, Uint::from(1));
     }
+}
 
-    #[cfg(feature = "solana")]
-    mod solana_sign {
-        use {
-            super::super::*,
-            solana_sdk::{
-                hash::Hash,
-                message::{Message, VersionedMessage},
-                pubkey::Pubkey,
-            },
-            solana_system_interface::instruction as system_instruction,
-        };
+#[cfg(all(test, feature = "solana"))]
+mod solana_sign_tests {
+    use {
+        super::*,
+        solana_sdk::{
+            hash::Hash,
+            message::{Message, VersionedMessage},
+            pubkey::Pubkey,
+        },
+        solana_system_interface::instruction as system_instruction,
+    };
 
-        fn unsigned_transfer_tx(
-            payer: &Pubkey,
-            recipient: &Pubkey,
-            lamports: u64,
-        ) -> VersionedTransaction {
-            let ix = system_instruction::transfer(payer, recipient, lamports);
-            let mut msg = Message::new(&[ix], Some(payer));
-            msg.recent_blockhash = Hash::new_from_array([7u8; 32]);
-            VersionedTransaction {
-                signatures: vec![SolanaSignature::default()],
-                message: VersionedMessage::Legacy(msg),
-            }
+    fn unsigned_transfer_tx(
+        payer: &Pubkey,
+        recipient: &Pubkey,
+        lamports: u64,
+    ) -> VersionedTransaction {
+        let ix = system_instruction::transfer(payer, recipient, lamports);
+        let mut msg = Message::new(&[ix], Some(payer));
+        msg.recent_blockhash = Hash::new_from_array([7u8; 32]);
+        VersionedTransaction {
+            signatures: vec![SolanaSignature::default()],
+            message: VersionedMessage::Legacy(msg),
         }
+    }
 
-        #[test]
-        fn signs_and_verifies() {
-            let payer = SolanaKeypair::new();
-            let recipient = SolanaKeypair::new();
-            let tx =
-                unsigned_transfer_tx(&payer.pubkey(), &recipient.pubkey(), 1);
+    #[test]
+    fn signs_and_verifies() {
+        let payer = SolanaKeypair::new();
+        let recipient = SolanaKeypair::new();
+        let tx = unsigned_transfer_tx(&payer.pubkey(), &recipient.pubkey(), 1);
 
-            let signed = solana_sign_transaction(payer.insecure_clone(), tx)
-                .expect("sign");
+        let signed =
+            solana_sign_transaction(payer.insecure_clone(), tx).expect("sign");
 
-            assert_eq!(signed.transaction.signatures.len(), 1);
-            assert_eq!(signed.transaction.signatures[0], signed.signature);
-            assert!(signed.signature.verify(
+        assert_eq!(signed.transaction.signatures.len(), 1);
+        assert_eq!(signed.transaction.signatures[0], signed.signature);
+        assert!(signed.signature.verify(
+            payer.pubkey().as_ref(),
+            &signed.transaction.message.serialize(),
+        ));
+    }
+
+    #[test]
+    fn rejects_non_signer_keypair() {
+        let payer = SolanaKeypair::new();
+        let recipient = SolanaKeypair::new();
+        let stranger = SolanaKeypair::new();
+        let tx = unsigned_transfer_tx(&payer.pubkey(), &recipient.pubkey(), 1);
+
+        let err = solana_sign_transaction(stranger.insecure_clone(), tx)
+            .expect_err("should reject");
+        assert!(matches!(
+            err,
+            SolanaSignTransactionError::SignerNotRequired { .. }
+        ));
+    }
+
+    #[test]
+    fn sign_all_preserves_order_and_signs_each() {
+        let payer = SolanaKeypair::new();
+        let recipient = SolanaKeypair::new();
+        let txs = (1..=3u64)
+            .map(|n| {
+                unsigned_transfer_tx(&payer.pubkey(), &recipient.pubkey(), n)
+            })
+            .collect::<Vec<_>>();
+
+        let signed =
+            solana_sign_all_transactions(payer.insecure_clone(), txs.clone())
+                .expect("sign all");
+
+        assert_eq!(signed.len(), 3);
+        for (i, s) in signed.iter().enumerate() {
+            assert!(s.signature.verify(
                 payer.pubkey().as_ref(),
-                &signed.transaction.message.serialize(),
+                &s.transaction.message.serialize(),
             ));
+            assert_eq!(s.transaction.signatures[0], s.signature);
+            let expected = &txs[i].message.serialize();
+            assert_eq!(&s.transaction.message.serialize(), expected);
         }
+    }
 
-        #[test]
-        fn rejects_non_signer_keypair() {
-            let payer = SolanaKeypair::new();
-            let recipient = SolanaKeypair::new();
-            let stranger = SolanaKeypair::new();
-            let tx =
-                unsigned_transfer_tx(&payer.pubkey(), &recipient.pubkey(), 1);
+    #[test]
+    fn sign_message_matches_sign_prehash() {
+        let kp = SolanaKeypair::new();
+        let msg: Bytes = Bytes::from_static(b"hello solana");
+        let a = solana_sign_message(kp.insecure_clone(), msg.clone());
+        let b = solana_sign_prehash(kp.insecure_clone(), msg);
+        assert_eq!(a, b);
+    }
 
-            let err = solana_sign_transaction(stranger.insecure_clone(), tx)
-                .expect_err("should reject");
-            assert!(matches!(
-                err,
-                SolanaSignTransactionError::SignerNotRequired { .. }
-            ));
-        }
+    #[test]
+    fn pads_signatures_when_short() {
+        let payer = SolanaKeypair::new();
+        let recipient = SolanaKeypair::new();
+        let mut tx =
+            unsigned_transfer_tx(&payer.pubkey(), &recipient.pubkey(), 42);
+        tx.signatures.clear();
 
-        #[test]
-        fn sign_all_preserves_order_and_signs_each() {
-            let payer = SolanaKeypair::new();
-            let recipient = SolanaKeypair::new();
-            let txs = (1..=3u64)
-                .map(|n| {
-                    unsigned_transfer_tx(
-                        &payer.pubkey(),
-                        &recipient.pubkey(),
-                        n,
-                    )
-                })
-                .collect::<Vec<_>>();
-
-            let signed = solana_sign_all_transactions(
-                payer.insecure_clone(),
-                txs.clone(),
-            )
-            .expect("sign all");
-
-            assert_eq!(signed.len(), 3);
-            for (i, s) in signed.iter().enumerate() {
-                assert!(s.signature.verify(
-                    payer.pubkey().as_ref(),
-                    &s.transaction.message.serialize(),
-                ));
-                assert_eq!(s.transaction.signatures[0], s.signature);
-                // ordering: lamports field of the transfer ix encodes i+1
-                let expected = &txs[i].message.serialize();
-                assert_eq!(&s.transaction.message.serialize(), expected);
-            }
-        }
-
-        #[test]
-        fn sign_message_matches_sign_prehash() {
-            let kp = SolanaKeypair::new();
-            let msg: Bytes = Bytes::from_static(b"hello solana");
-            let a = solana_sign_message(kp.insecure_clone(), msg.clone());
-            let b = solana_sign_prehash(kp.insecure_clone(), msg);
-            assert_eq!(a, b);
-        }
-
-        #[test]
-        fn pads_signatures_when_short() {
-            let payer = SolanaKeypair::new();
-            let recipient = SolanaKeypair::new();
-            let mut tx =
-                unsigned_transfer_tx(&payer.pubkey(), &recipient.pubkey(), 42);
-            tx.signatures.clear();
-
-            let signed = solana_sign_transaction(payer.insecure_clone(), tx)
-                .expect("sign");
-            assert_eq!(signed.transaction.signatures.len(), 1);
-            assert_eq!(signed.transaction.signatures[0], signed.signature);
-        }
+        let signed =
+            solana_sign_transaction(payer.insecure_clone(), tx).expect("sign");
+        assert_eq!(signed.transaction.signatures.len(), 1);
+        assert_eq!(signed.transaction.signatures[0], signed.signature);
     }
 }

--- a/crates/yttrium/src/uniffi_compat/mod.rs
+++ b/crates/yttrium/src/uniffi_compat/mod.rs
@@ -550,6 +550,81 @@ fn solana_sign_prehash(
 }
 
 #[cfg(feature = "solana")]
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Record)]
+pub struct SolanaSignedTransaction {
+    pub signature: SolanaSignature,
+    pub transaction: VersionedTransaction,
+}
+
+#[cfg(feature = "solana")]
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Error, thiserror::Error)]
+pub enum SolanaSignTransactionError {
+    #[error(
+        "signer pubkey {pubkey} is not a required signer of this transaction"
+    )]
+    SignerNotRequired { pubkey: String },
+}
+
+#[cfg(feature = "solana")]
+fn sign_versioned_transaction(
+    keypair: &SolanaKeypair,
+    mut transaction: VersionedTransaction,
+) -> Result<SolanaSignedTransaction, SolanaSignTransactionError> {
+    let pubkey = keypair.pubkey();
+    let num_required =
+        transaction.message.header().num_required_signatures as usize;
+    // Only the static account keys can be signers; ALT-loaded keys cannot.
+    let index = transaction
+        .message
+        .static_account_keys()
+        .iter()
+        .take(num_required)
+        .position(|k| k == &pubkey)
+        .ok_or_else(|| SolanaSignTransactionError::SignerNotRequired {
+            pubkey: pubkey.to_string(),
+        })?;
+
+    let signature = keypair.sign_message(&transaction.message.serialize());
+
+    if transaction.signatures.len() < num_required {
+        transaction.signatures.resize(num_required, SolanaSignature::default());
+    }
+    transaction.signatures[index] = signature;
+
+    Ok(SolanaSignedTransaction { signature, transaction })
+}
+
+#[cfg(feature = "solana")]
+#[uniffi::export]
+fn solana_sign_transaction(
+    keypair: SolanaKeypair,
+    transaction: VersionedTransaction,
+) -> Result<SolanaSignedTransaction, SolanaSignTransactionError> {
+    sign_versioned_transaction(&keypair, transaction)
+}
+
+#[cfg(feature = "solana")]
+#[uniffi::export]
+fn solana_sign_all_transactions(
+    keypair: SolanaKeypair,
+    transactions: Vec<VersionedTransaction>,
+) -> Result<Vec<SolanaSignedTransaction>, SolanaSignTransactionError> {
+    transactions
+        .into_iter()
+        .map(|tx| sign_versioned_transaction(&keypair, tx))
+        .collect()
+}
+
+#[cfg(feature = "solana")]
+#[uniffi::export]
+fn solana_sign_message(
+    keypair: SolanaKeypair,
+    message: Bytes,
+) -> SolanaSignature {
+    keypair.sign_message(&message)
+}
+
+#[cfg(feature = "solana")]
 #[uniffi::export]
 fn solana_generate_keypair() -> SolanaKeypair {
     SolanaKeypair::new()
@@ -743,5 +818,122 @@ mod tests {
         let s = "0x1";
         let n = s.parse::<U256>().unwrap();
         assert_eq!(n, Uint::from(1));
+    }
+
+    #[cfg(feature = "solana")]
+    mod solana_sign {
+        use {
+            super::super::*,
+            solana_sdk::{
+                hash::Hash,
+                message::{Message, VersionedMessage},
+                pubkey::Pubkey,
+            },
+            solana_system_interface::instruction as system_instruction,
+        };
+
+        fn unsigned_transfer_tx(
+            payer: &Pubkey,
+            recipient: &Pubkey,
+            lamports: u64,
+        ) -> VersionedTransaction {
+            let ix = system_instruction::transfer(payer, recipient, lamports);
+            let mut msg = Message::new(&[ix], Some(payer));
+            msg.recent_blockhash = Hash::new_from_array([7u8; 32]);
+            VersionedTransaction {
+                signatures: vec![SolanaSignature::default()],
+                message: VersionedMessage::Legacy(msg),
+            }
+        }
+
+        #[test]
+        fn signs_and_verifies() {
+            let payer = SolanaKeypair::new();
+            let recipient = SolanaKeypair::new();
+            let tx =
+                unsigned_transfer_tx(&payer.pubkey(), &recipient.pubkey(), 1);
+
+            let signed = solana_sign_transaction(payer.insecure_clone(), tx)
+                .expect("sign");
+
+            assert_eq!(signed.transaction.signatures.len(), 1);
+            assert_eq!(signed.transaction.signatures[0], signed.signature);
+            assert!(signed.signature.verify(
+                payer.pubkey().as_ref(),
+                &signed.transaction.message.serialize(),
+            ));
+        }
+
+        #[test]
+        fn rejects_non_signer_keypair() {
+            let payer = SolanaKeypair::new();
+            let recipient = SolanaKeypair::new();
+            let stranger = SolanaKeypair::new();
+            let tx =
+                unsigned_transfer_tx(&payer.pubkey(), &recipient.pubkey(), 1);
+
+            let err = solana_sign_transaction(stranger.insecure_clone(), tx)
+                .expect_err("should reject");
+            assert!(matches!(
+                err,
+                SolanaSignTransactionError::SignerNotRequired { .. }
+            ));
+        }
+
+        #[test]
+        fn sign_all_preserves_order_and_signs_each() {
+            let payer = SolanaKeypair::new();
+            let recipient = SolanaKeypair::new();
+            let txs = (1..=3u64)
+                .map(|n| {
+                    unsigned_transfer_tx(
+                        &payer.pubkey(),
+                        &recipient.pubkey(),
+                        n,
+                    )
+                })
+                .collect::<Vec<_>>();
+
+            let signed = solana_sign_all_transactions(
+                payer.insecure_clone(),
+                txs.clone(),
+            )
+            .expect("sign all");
+
+            assert_eq!(signed.len(), 3);
+            for (i, s) in signed.iter().enumerate() {
+                assert!(s.signature.verify(
+                    payer.pubkey().as_ref(),
+                    &s.transaction.message.serialize(),
+                ));
+                assert_eq!(s.transaction.signatures[0], s.signature);
+                // ordering: lamports field of the transfer ix encodes i+1
+                let expected = &txs[i].message.serialize();
+                assert_eq!(&s.transaction.message.serialize(), expected);
+            }
+        }
+
+        #[test]
+        fn sign_message_matches_sign_prehash() {
+            let kp = SolanaKeypair::new();
+            let msg: Bytes = Bytes::from_static(b"hello solana");
+            let a = solana_sign_message(kp.insecure_clone(), msg.clone());
+            let b = solana_sign_prehash(kp.insecure_clone(), msg);
+            assert_eq!(a, b);
+        }
+
+        #[test]
+        fn pads_signatures_when_short() {
+            let payer = SolanaKeypair::new();
+            let recipient = SolanaKeypair::new();
+            let mut tx =
+                unsigned_transfer_tx(&payer.pubkey(), &recipient.pubkey(), 42);
+            tx.signatures.clear();
+
+            let signed = solana_sign_transaction(payer.insecure_clone(), tx)
+                .expect("sign");
+            assert_eq!(signed.transaction.signatures.len(), 1);
+            assert_eq!(signed.transaction.signatures[0], signed.signature);
+        }
     }
 }

--- a/crates/yttrium_dart/lib/generated/frb_generated.dart
+++ b/crates/yttrium_dart/lib/generated/frb_generated.dart
@@ -12,8 +12,9 @@ import 'lib.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 /// Main entrypoint of the Rust API
-class YttriumDart extends BaseEntrypoint<YttriumDartApi, YttriumDartApiImpl,
-    YttriumDartWire> {
+class YttriumDart
+    extends
+        BaseEntrypoint<YttriumDartApi, YttriumDartApiImpl, YttriumDartWire> {
   @internal
   static final instance = YttriumDart._();
 
@@ -34,12 +35,8 @@ class YttriumDart extends BaseEntrypoint<YttriumDartApi, YttriumDartApiImpl,
 
   /// Initialize flutter_rust_bridge in mock mode.
   /// No libraries for FFI are loaded.
-  static void initMock({
-    required YttriumDartApi api,
-  }) {
-    instance.initMockImpl(
-      api: api,
-    );
+  static void initMock({required YttriumDartApi api}) {
+    instance.initMockImpl(api: api);
   }
 
   /// Dispose flutter_rust_bridge
@@ -50,7 +47,7 @@ class YttriumDart extends BaseEntrypoint<YttriumDartApi, YttriumDartApiImpl,
 
   @override
   ApiImplConstructor<YttriumDartApiImpl, YttriumDartWire>
-      get apiImplConstructor => YttriumDartApiImpl.new;
+  get apiImplConstructor => YttriumDartApiImpl.new;
 
   @override
   WireConstructor<YttriumDartWire> get wireConstructor =>
@@ -67,57 +64,85 @@ class YttriumDart extends BaseEntrypoint<YttriumDartApi, YttriumDartApiImpl,
   String get codegenVersion => '2.10.0';
 
   @override
-  int get rustContentHash => 1433861761;
+  int get rustContentHash => -648847146;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
-    stem: 'yttrium_dart',
-    ioDirectory: 'rust/target/release/',
-    webPrefix: 'pkg/',
-  );
+        stem: 'yttrium_dart',
+        ioDirectory: 'rust/target/release/',
+        webPrefix: 'pkg/',
+      );
 }
 
 abstract class YttriumDartApi extends BaseApi {
-  String crateChainAbstractionClientAutoAccessorGetProjectId(
-      {required ChainAbstractionClient that});
+  String crateChainAbstractionClientAutoAccessorGetProjectId({
+    required ChainAbstractionClient that,
+  });
 
-  void crateChainAbstractionClientAutoAccessorSetProjectId(
-      {required ChainAbstractionClient that, required String projectId});
+  void crateChainAbstractionClientAutoAccessorSetProjectId({
+    required ChainAbstractionClient that,
+    required String projectId,
+  });
 
-  Future<String> crateChainAbstractionClientErc20TokenBalance(
-      {required ChainAbstractionClient that,
-      required String chainId,
-      required Address token,
-      required Address owner});
+  Future<String> crateChainAbstractionClientErc20TokenBalance({
+    required ChainAbstractionClient that,
+    required String chainId,
+    required Address token,
+    required Address owner,
+  });
 
-  Future<Eip1559Estimation> crateChainAbstractionClientEstimateFees(
-      {required ChainAbstractionClient that, required String chainId});
+  Future<Eip1559Estimation> crateChainAbstractionClientEstimateFees({
+    required ChainAbstractionClient that,
+    required String chainId,
+  });
 
-  Future<UiFields> crateChainAbstractionClientGetUiFields(
-      {required ChainAbstractionClient that,
-      required PrepareResponseAvailable routeResponse,
-      required Currency currency});
+  Future<UiFields> crateChainAbstractionClientGetUiFields({
+    required ChainAbstractionClient that,
+    required PrepareResponseAvailable routeResponse,
+    required Currency currency,
+  });
 
-  Future<ChainAbstractionClient> crateChainAbstractionClientNew(
-      {required String projectId, required PulseMetadata pulseMetadata});
+  Future<ChainAbstractionClient> crateChainAbstractionClientNew({
+    required String projectId,
+    required PulseMetadata pulseMetadata,
+  });
 
-  Future<PrepareResponse> crateChainAbstractionClientPrepare(
-      {required ChainAbstractionClient that,
-      required String chainId,
-      required Address from,
-      required Call call,
-      required List<String> accounts,
-      required bool useLifi});
+  Future<PrepareResponse> crateChainAbstractionClientPrepare({
+    required ChainAbstractionClient that,
+    required String chainId,
+    required Address from,
+    required Call call,
+    required List<String> accounts,
+    required bool useLifi,
+  });
 
-  Future<StatusResponse> crateChainAbstractionClientStatus(
-      {required ChainAbstractionClient that, required String orchestrationId});
+  Future<StatusResponse> crateChainAbstractionClientStatus({
+    required ChainAbstractionClient that,
+    required String orchestrationId,
+  });
 
   Future<StatusResponseCompleted>
-      crateChainAbstractionClientWaitForSuccessWithTimeout(
-          {required ChainAbstractionClient that,
-          required String orchestrationId,
-          required BigInt checkIn,
-          required BigInt timeout});
+  crateChainAbstractionClientWaitForSuccessWithTimeout({
+    required ChainAbstractionClient that,
+    required String orchestrationId,
+    required BigInt checkIn,
+    required BigInt timeout,
+  });
+
+  Future<List<SolanaSignedTransactionDart>> crateSolanaSignAllTransactions({
+    required String keypairBase58,
+    required List<String> transactionsBase64,
+  });
+
+  Future<String> crateSolanaSignMessage({
+    required String keypairBase58,
+    required List<int> message,
+  });
+
+  Future<SolanaSignedTransactionDart> crateSolanaSignTransaction({
+    required String keypairBase58,
+    required String transactionBase64,
+  });
 
   RustArcIncrementStrongCountFnType get rust_arc_increment_strong_count_Address;
 
@@ -132,72 +157,72 @@ abstract class YttriumDartApi extends BaseApi {
   CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_CallPtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_ChainAbstractionClient;
+  get rust_arc_increment_strong_count_ChainAbstractionClient;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_ChainAbstractionClient;
+  get rust_arc_decrement_strong_count_ChainAbstractionClient;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_ChainAbstractionClientPtr;
+  get rust_arc_decrement_strong_count_ChainAbstractionClientPtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_Currency;
+  get rust_arc_increment_strong_count_Currency;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_Currency;
+  get rust_arc_decrement_strong_count_Currency;
 
   CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_CurrencyPtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_PrepareResponse;
+  get rust_arc_increment_strong_count_PrepareResponse;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_PrepareResponse;
+  get rust_arc_decrement_strong_count_PrepareResponse;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_PrepareResponsePtr;
+  get rust_arc_decrement_strong_count_PrepareResponsePtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_PrepareResponseAvailable;
+  get rust_arc_increment_strong_count_PrepareResponseAvailable;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_PrepareResponseAvailable;
+  get rust_arc_decrement_strong_count_PrepareResponseAvailable;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_PrepareResponseAvailablePtr;
+  get rust_arc_decrement_strong_count_PrepareResponseAvailablePtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_PulseMetadata;
+  get rust_arc_increment_strong_count_PulseMetadata;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_PulseMetadata;
+  get rust_arc_decrement_strong_count_PulseMetadata;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_PulseMetadataPtr;
+  get rust_arc_decrement_strong_count_PulseMetadataPtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_StatusResponse;
+  get rust_arc_increment_strong_count_StatusResponse;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_StatusResponse;
+  get rust_arc_decrement_strong_count_StatusResponse;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_StatusResponsePtr;
+  get rust_arc_decrement_strong_count_StatusResponsePtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_StatusResponseCompleted;
+  get rust_arc_increment_strong_count_StatusResponseCompleted;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_StatusResponseCompleted;
+  get rust_arc_decrement_strong_count_StatusResponseCompleted;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_StatusResponseCompletedPtr;
+  get rust_arc_decrement_strong_count_StatusResponseCompletedPtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_UiFields;
+  get rust_arc_increment_strong_count_UiFields;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_UiFields;
+  get rust_arc_decrement_strong_count_UiFields;
 
   CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_UiFieldsPtr;
 }
@@ -212,87 +237,113 @@ class YttriumDartApiImpl extends YttriumDartApiImplPlatform
   });
 
   @override
-  String crateChainAbstractionClientAutoAccessorGetProjectId(
-      {required ChainAbstractionClient that}) {
-    return handler.executeSync(SyncTask(
-      callFfi: () {
-        final serializer = SseSerializer(generalizedFrbRustBinding);
-        sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-            that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1)!;
-      },
-      codec: SseCodec(
-        decodeSuccessData: sse_decode_String,
-        decodeErrorData: null,
+  String crateChainAbstractionClientAutoAccessorGetProjectId({
+    required ChainAbstractionClient that,
+  }) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+            that,
+            serializer,
+          );
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_String,
+          decodeErrorData: null,
+        ),
+        constMeta:
+            kCrateChainAbstractionClientAutoAccessorGetProjectIdConstMeta,
+        argValues: [that],
+        apiImpl: this,
       ),
-      constMeta: kCrateChainAbstractionClientAutoAccessorGetProjectIdConstMeta,
-      argValues: [that],
-      apiImpl: this,
-    ));
+    );
   }
 
   TaskConstMeta
-      get kCrateChainAbstractionClientAutoAccessorGetProjectIdConstMeta =>
-          const TaskConstMeta(
-            debugName: 'ChainAbstractionClient_auto_accessor_get_project_id',
-            argNames: ['that'],
-          );
+  get kCrateChainAbstractionClientAutoAccessorGetProjectIdConstMeta =>
+      const TaskConstMeta(
+        debugName: 'ChainAbstractionClient_auto_accessor_get_project_id',
+        argNames: ['that'],
+      );
 
   @override
-  void crateChainAbstractionClientAutoAccessorSetProjectId(
-      {required ChainAbstractionClient that, required String projectId}) {
-    return handler.executeSync(SyncTask(
-      callFfi: () {
-        final serializer = SseSerializer(generalizedFrbRustBinding);
-        sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-            that, serializer);
-        sse_encode_String(projectId, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 2)!;
-      },
-      codec: SseCodec(
-        decodeSuccessData: sse_decode_unit,
-        decodeErrorData: null,
+  void crateChainAbstractionClientAutoAccessorSetProjectId({
+    required ChainAbstractionClient that,
+    required String projectId,
+  }) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+            that,
+            serializer,
+          );
+          sse_encode_String(projectId, serializer);
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 2)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta:
+            kCrateChainAbstractionClientAutoAccessorSetProjectIdConstMeta,
+        argValues: [that, projectId],
+        apiImpl: this,
       ),
-      constMeta: kCrateChainAbstractionClientAutoAccessorSetProjectIdConstMeta,
-      argValues: [that, projectId],
-      apiImpl: this,
-    ));
+    );
   }
 
   TaskConstMeta
-      get kCrateChainAbstractionClientAutoAccessorSetProjectIdConstMeta =>
-          const TaskConstMeta(
-            debugName: 'ChainAbstractionClient_auto_accessor_set_project_id',
-            argNames: ['that', 'projectId'],
-          );
+  get kCrateChainAbstractionClientAutoAccessorSetProjectIdConstMeta =>
+      const TaskConstMeta(
+        debugName: 'ChainAbstractionClient_auto_accessor_set_project_id',
+        argNames: ['that', 'projectId'],
+      );
 
   @override
-  Future<String> crateChainAbstractionClientErc20TokenBalance(
-      {required ChainAbstractionClient that,
-      required String chainId,
-      required Address token,
-      required Address owner}) {
-    return handler.executeNormal(NormalTask(
-      callFfi: (port_) {
-        final serializer = SseSerializer(generalizedFrbRustBinding);
-        sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-            that, serializer);
-        sse_encode_String(chainId, serializer);
-        sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
-            token, serializer);
-        sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
-            owner, serializer);
-        pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 3, port: port_);
-      },
-      codec: SseCodec(
-        decodeSuccessData: sse_decode_String,
-        decodeErrorData: sse_decode_error,
+  Future<String> crateChainAbstractionClientErc20TokenBalance({
+    required ChainAbstractionClient that,
+    required String chainId,
+    required Address token,
+    required Address owner,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+            that,
+            serializer,
+          );
+          sse_encode_String(chainId, serializer);
+          sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
+            token,
+            serializer,
+          );
+          sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
+            owner,
+            serializer,
+          );
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 3,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_String,
+          decodeErrorData: sse_decode_error,
+        ),
+        constMeta: kCrateChainAbstractionClientErc20TokenBalanceConstMeta,
+        argValues: [that, chainId, token, owner],
+        apiImpl: this,
       ),
-      constMeta: kCrateChainAbstractionClientErc20TokenBalanceConstMeta,
-      argValues: [that, chainId, token, owner],
-      apiImpl: this,
-    ));
+    );
   }
 
   TaskConstMeta get kCrateChainAbstractionClientErc20TokenBalanceConstMeta =>
@@ -302,25 +353,35 @@ class YttriumDartApiImpl extends YttriumDartApiImplPlatform
       );
 
   @override
-  Future<Eip1559Estimation> crateChainAbstractionClientEstimateFees(
-      {required ChainAbstractionClient that, required String chainId}) {
-    return handler.executeNormal(NormalTask(
-      callFfi: (port_) {
-        final serializer = SseSerializer(generalizedFrbRustBinding);
-        sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-            that, serializer);
-        sse_encode_String(chainId, serializer);
-        pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 4, port: port_);
-      },
-      codec: SseCodec(
-        decodeSuccessData: sse_decode_eip_1559_estimation,
-        decodeErrorData: sse_decode_error,
+  Future<Eip1559Estimation> crateChainAbstractionClientEstimateFees({
+    required ChainAbstractionClient that,
+    required String chainId,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+            that,
+            serializer,
+          );
+          sse_encode_String(chainId, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 4,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_eip_1559_estimation,
+          decodeErrorData: sse_decode_error,
+        ),
+        constMeta: kCrateChainAbstractionClientEstimateFeesConstMeta,
+        argValues: [that, chainId],
+        apiImpl: this,
       ),
-      constMeta: kCrateChainAbstractionClientEstimateFeesConstMeta,
-      argValues: [that, chainId],
-      apiImpl: this,
-    ));
+    );
   }
 
   TaskConstMeta get kCrateChainAbstractionClientEstimateFeesConstMeta =>
@@ -330,31 +391,44 @@ class YttriumDartApiImpl extends YttriumDartApiImplPlatform
       );
 
   @override
-  Future<UiFields> crateChainAbstractionClientGetUiFields(
-      {required ChainAbstractionClient that,
-      required PrepareResponseAvailable routeResponse,
-      required Currency currency}) {
-    return handler.executeNormal(NormalTask(
-      callFfi: (port_) {
-        final serializer = SseSerializer(generalizedFrbRustBinding);
-        sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-            that, serializer);
-        sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
-            routeResponse, serializer);
-        sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
-            currency, serializer);
-        pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 5, port: port_);
-      },
-      codec: SseCodec(
-        decodeSuccessData:
-            sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields,
-        decodeErrorData: sse_decode_error,
+  Future<UiFields> crateChainAbstractionClientGetUiFields({
+    required ChainAbstractionClient that,
+    required PrepareResponseAvailable routeResponse,
+    required Currency currency,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+            that,
+            serializer,
+          );
+          sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
+            routeResponse,
+            serializer,
+          );
+          sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
+            currency,
+            serializer,
+          );
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 5,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData:
+              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields,
+          decodeErrorData: sse_decode_error,
+        ),
+        constMeta: kCrateChainAbstractionClientGetUiFieldsConstMeta,
+        argValues: [that, routeResponse, currency],
+        apiImpl: this,
       ),
-      constMeta: kCrateChainAbstractionClientGetUiFieldsConstMeta,
-      argValues: [that, routeResponse, currency],
-      apiImpl: this,
-    ));
+    );
   }
 
   TaskConstMeta get kCrateChainAbstractionClientGetUiFieldsConstMeta =>
@@ -364,26 +438,36 @@ class YttriumDartApiImpl extends YttriumDartApiImplPlatform
       );
 
   @override
-  Future<ChainAbstractionClient> crateChainAbstractionClientNew(
-      {required String projectId, required PulseMetadata pulseMetadata}) {
-    return handler.executeNormal(NormalTask(
-      callFfi: (port_) {
-        final serializer = SseSerializer(generalizedFrbRustBinding);
-        sse_encode_String(projectId, serializer);
-        sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
-            pulseMetadata, serializer);
-        pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 6, port: port_);
-      },
-      codec: SseCodec(
-        decodeSuccessData:
-            sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient,
-        decodeErrorData: null,
+  Future<ChainAbstractionClient> crateChainAbstractionClientNew({
+    required String projectId,
+    required PulseMetadata pulseMetadata,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(projectId, serializer);
+          sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
+            pulseMetadata,
+            serializer,
+          );
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 6,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData:
+              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateChainAbstractionClientNewConstMeta,
+        argValues: [projectId, pulseMetadata],
+        apiImpl: this,
       ),
-      constMeta: kCrateChainAbstractionClientNewConstMeta,
-      argValues: [projectId, pulseMetadata],
-      apiImpl: this,
-    ));
+    );
   }
 
   TaskConstMeta get kCrateChainAbstractionClientNewConstMeta =>
@@ -393,37 +477,50 @@ class YttriumDartApiImpl extends YttriumDartApiImplPlatform
       );
 
   @override
-  Future<PrepareResponse> crateChainAbstractionClientPrepare(
-      {required ChainAbstractionClient that,
-      required String chainId,
-      required Address from,
-      required Call call,
-      required List<String> accounts,
-      required bool useLifi}) {
-    return handler.executeNormal(NormalTask(
-      callFfi: (port_) {
-        final serializer = SseSerializer(generalizedFrbRustBinding);
-        sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-            that, serializer);
-        sse_encode_String(chainId, serializer);
-        sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
-            from, serializer);
-        sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
-            call, serializer);
-        sse_encode_list_String(accounts, serializer);
-        sse_encode_bool(useLifi, serializer);
-        pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 7, port: port_);
-      },
-      codec: SseCodec(
-        decodeSuccessData:
-            sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse,
-        decodeErrorData: sse_decode_error,
+  Future<PrepareResponse> crateChainAbstractionClientPrepare({
+    required ChainAbstractionClient that,
+    required String chainId,
+    required Address from,
+    required Call call,
+    required List<String> accounts,
+    required bool useLifi,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+            that,
+            serializer,
+          );
+          sse_encode_String(chainId, serializer);
+          sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
+            from,
+            serializer,
+          );
+          sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
+            call,
+            serializer,
+          );
+          sse_encode_list_String(accounts, serializer);
+          sse_encode_bool(useLifi, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 7,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData:
+              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse,
+          decodeErrorData: sse_decode_error,
+        ),
+        constMeta: kCrateChainAbstractionClientPrepareConstMeta,
+        argValues: [that, chainId, from, call, accounts, useLifi],
+        apiImpl: this,
       ),
-      constMeta: kCrateChainAbstractionClientPrepareConstMeta,
-      argValues: [that, chainId, from, call, accounts, useLifi],
-      apiImpl: this,
-    ));
+    );
   }
 
   TaskConstMeta get kCrateChainAbstractionClientPrepareConstMeta =>
@@ -433,26 +530,36 @@ class YttriumDartApiImpl extends YttriumDartApiImplPlatform
       );
 
   @override
-  Future<StatusResponse> crateChainAbstractionClientStatus(
-      {required ChainAbstractionClient that, required String orchestrationId}) {
-    return handler.executeNormal(NormalTask(
-      callFfi: (port_) {
-        final serializer = SseSerializer(generalizedFrbRustBinding);
-        sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-            that, serializer);
-        sse_encode_String(orchestrationId, serializer);
-        pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 8, port: port_);
-      },
-      codec: SseCodec(
-        decodeSuccessData:
-            sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse,
-        decodeErrorData: sse_decode_error,
+  Future<StatusResponse> crateChainAbstractionClientStatus({
+    required ChainAbstractionClient that,
+    required String orchestrationId,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+            that,
+            serializer,
+          );
+          sse_encode_String(orchestrationId, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 8,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData:
+              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse,
+          decodeErrorData: sse_decode_error,
+        ),
+        constMeta: kCrateChainAbstractionClientStatusConstMeta,
+        argValues: [that, orchestrationId],
+        apiImpl: this,
       ),
-      constMeta: kCrateChainAbstractionClientStatusConstMeta,
-      argValues: [that, orchestrationId],
-      apiImpl: this,
-    ));
+    );
   }
 
   TaskConstMeta get kCrateChainAbstractionClientStatusConstMeta =>
@@ -463,298 +570,443 @@ class YttriumDartApiImpl extends YttriumDartApiImplPlatform
 
   @override
   Future<StatusResponseCompleted>
-      crateChainAbstractionClientWaitForSuccessWithTimeout(
-          {required ChainAbstractionClient that,
-          required String orchestrationId,
-          required BigInt checkIn,
-          required BigInt timeout}) {
-    return handler.executeNormal(NormalTask(
-      callFfi: (port_) {
-        final serializer = SseSerializer(generalizedFrbRustBinding);
-        sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-            that, serializer);
-        sse_encode_String(orchestrationId, serializer);
-        sse_encode_u_64(checkIn, serializer);
-        sse_encode_u_64(timeout, serializer);
-        pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 9, port: port_);
-      },
-      codec: SseCodec(
-        decodeSuccessData:
-            sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted,
-        decodeErrorData: sse_decode_error,
+  crateChainAbstractionClientWaitForSuccessWithTimeout({
+    required ChainAbstractionClient that,
+    required String orchestrationId,
+    required BigInt checkIn,
+    required BigInt timeout,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+            that,
+            serializer,
+          );
+          sse_encode_String(orchestrationId, serializer);
+          sse_encode_u_64(checkIn, serializer);
+          sse_encode_u_64(timeout, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 9,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData:
+              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted,
+          decodeErrorData: sse_decode_error,
+        ),
+        constMeta:
+            kCrateChainAbstractionClientWaitForSuccessWithTimeoutConstMeta,
+        argValues: [that, orchestrationId, checkIn, timeout],
+        apiImpl: this,
       ),
-      constMeta: kCrateChainAbstractionClientWaitForSuccessWithTimeoutConstMeta,
-      argValues: [that, orchestrationId, checkIn, timeout],
-      apiImpl: this,
-    ));
+    );
   }
 
   TaskConstMeta
-      get kCrateChainAbstractionClientWaitForSuccessWithTimeoutConstMeta =>
-          const TaskConstMeta(
-            debugName: 'ChainAbstractionClient_wait_for_success_with_timeout',
-            argNames: ['that', 'orchestrationId', 'checkIn', 'timeout'],
+  get kCrateChainAbstractionClientWaitForSuccessWithTimeoutConstMeta =>
+      const TaskConstMeta(
+        debugName: 'ChainAbstractionClient_wait_for_success_with_timeout',
+        argNames: ['that', 'orchestrationId', 'checkIn', 'timeout'],
+      );
+
+  @override
+  Future<List<SolanaSignedTransactionDart>> crateSolanaSignAllTransactions({
+    required String keypairBase58,
+    required List<String> transactionsBase64,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(keypairBase58, serializer);
+          sse_encode_list_String(transactionsBase64, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 10,
+            port: port_,
           );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_list_solana_signed_transaction_dart,
+          decodeErrorData: sse_decode_solana_sign_error,
+        ),
+        constMeta: kCrateSolanaSignAllTransactionsConstMeta,
+        argValues: [keypairBase58, transactionsBase64],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateSolanaSignAllTransactionsConstMeta =>
+      const TaskConstMeta(
+        debugName: 'solana_sign_all_transactions',
+        argNames: ['keypairBase58', 'transactionsBase64'],
+      );
+
+  @override
+  Future<String> crateSolanaSignMessage({
+    required String keypairBase58,
+    required List<int> message,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(keypairBase58, serializer);
+          sse_encode_list_prim_u_8_loose(message, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 11,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_String,
+          decodeErrorData: sse_decode_solana_sign_error,
+        ),
+        constMeta: kCrateSolanaSignMessageConstMeta,
+        argValues: [keypairBase58, message],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateSolanaSignMessageConstMeta => const TaskConstMeta(
+    debugName: 'solana_sign_message',
+    argNames: ['keypairBase58', 'message'],
+  );
+
+  @override
+  Future<SolanaSignedTransactionDart> crateSolanaSignTransaction({
+    required String keypairBase58,
+    required String transactionBase64,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(keypairBase58, serializer);
+          sse_encode_String(transactionBase64, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 12,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_solana_signed_transaction_dart,
+          decodeErrorData: sse_decode_solana_sign_error,
+        ),
+        constMeta: kCrateSolanaSignTransactionConstMeta,
+        argValues: [keypairBase58, transactionBase64],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateSolanaSignTransactionConstMeta => const TaskConstMeta(
+    debugName: 'solana_sign_transaction',
+    argNames: ['keypairBase58', 'transactionBase64'],
+  );
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_Address => wire
-          .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress;
+  get rust_arc_increment_strong_count_Address => wire
+      .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_Address => wire
-          .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress;
-
-  RustArcIncrementStrongCountFnType get rust_arc_increment_strong_count_Call =>
-      wire.rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall;
-
-  RustArcDecrementStrongCountFnType get rust_arc_decrement_strong_count_Call =>
-      wire.rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall;
+  get rust_arc_decrement_strong_count_Address => wire
+      .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_ChainAbstractionClient => wire
-          .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient;
+  get rust_arc_increment_strong_count_Call => wire
+      .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_ChainAbstractionClient => wire
-          .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient;
+  get rust_arc_decrement_strong_count_Call => wire
+      .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_Currency => wire
-          .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency;
+  get rust_arc_increment_strong_count_ChainAbstractionClient => wire
+      .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_Currency => wire
-          .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency;
+  get rust_arc_decrement_strong_count_ChainAbstractionClient => wire
+      .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_PrepareResponse => wire
-          .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse;
+  get rust_arc_increment_strong_count_Currency => wire
+      .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_PrepareResponse => wire
-          .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse;
+  get rust_arc_decrement_strong_count_Currency => wire
+      .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_PrepareResponseAvailable => wire
-          .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable;
+  get rust_arc_increment_strong_count_PrepareResponse => wire
+      .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_PrepareResponseAvailable => wire
-          .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable;
+  get rust_arc_decrement_strong_count_PrepareResponse => wire
+      .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_PulseMetadata => wire
-          .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata;
+  get rust_arc_increment_strong_count_PrepareResponseAvailable => wire
+      .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_PulseMetadata => wire
-          .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata;
+  get rust_arc_decrement_strong_count_PrepareResponseAvailable => wire
+      .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_StatusResponse => wire
-          .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse;
+  get rust_arc_increment_strong_count_PulseMetadata => wire
+      .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_StatusResponse => wire
-          .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse;
+  get rust_arc_decrement_strong_count_PulseMetadata => wire
+      .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_StatusResponseCompleted => wire
-          .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted;
+  get rust_arc_increment_strong_count_StatusResponse => wire
+      .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_StatusResponseCompleted => wire
-          .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted;
+  get rust_arc_decrement_strong_count_StatusResponse => wire
+      .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_UiFields => wire
-          .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields;
+  get rust_arc_increment_strong_count_StatusResponseCompleted => wire
+      .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_UiFields => wire
-          .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields;
+  get rust_arc_decrement_strong_count_StatusResponseCompleted => wire
+      .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted;
+
+  RustArcIncrementStrongCountFnType
+  get rust_arc_increment_strong_count_UiFields => wire
+      .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields;
+
+  RustArcDecrementStrongCountFnType
+  get rust_arc_decrement_strong_count_UiFields => wire
+      .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields;
 
   @protected
   Address
-      dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
-          dynamic raw) {
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
+    dynamic raw,
+  ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return AddressImpl.frbInternalDcoDecode(raw as List<dynamic>);
   }
 
   @protected
   Call
-      dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
-          dynamic raw) {
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
+    dynamic raw,
+  ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return CallImpl.frbInternalDcoDecode(raw as List<dynamic>);
   }
 
   @protected
   ChainAbstractionClient
-      dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-          dynamic raw) {
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+    dynamic raw,
+  ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ChainAbstractionClientImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+      raw as List<dynamic>,
+    );
   }
 
   @protected
   Currency
-      dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
-          dynamic raw) {
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
+    dynamic raw,
+  ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return CurrencyImpl.frbInternalDcoDecode(raw as List<dynamic>);
   }
 
   @protected
   PrepareResponse
-      dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
-          dynamic raw) {
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
+    dynamic raw,
+  ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return PrepareResponseImpl.frbInternalDcoDecode(raw as List<dynamic>);
   }
 
   @protected
   PrepareResponseAvailable
-      dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
-          dynamic raw) {
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
+    dynamic raw,
+  ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return PrepareResponseAvailableImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+      raw as List<dynamic>,
+    );
   }
 
   @protected
   PulseMetadata
-      dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
-          dynamic raw) {
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
+    dynamic raw,
+  ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return PulseMetadataImpl.frbInternalDcoDecode(raw as List<dynamic>);
   }
 
   @protected
   StatusResponse
-      dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
-          dynamic raw) {
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
+    dynamic raw,
+  ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StatusResponseImpl.frbInternalDcoDecode(raw as List<dynamic>);
   }
 
   @protected
   StatusResponseCompleted
-      dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
-          dynamic raw) {
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
+    dynamic raw,
+  ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StatusResponseCompletedImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+      raw as List<dynamic>,
+    );
   }
 
   @protected
   UiFields
-      dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
-          dynamic raw) {
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
+    dynamic raw,
+  ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return UiFieldsImpl.frbInternalDcoDecode(raw as List<dynamic>);
   }
 
   @protected
   ChainAbstractionClient
-      dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-          dynamic raw) {
+  dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+    dynamic raw,
+  ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ChainAbstractionClientImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+      raw as List<dynamic>,
+    );
   }
 
   @protected
   ChainAbstractionClient
-      dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-          dynamic raw) {
+  dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+    dynamic raw,
+  ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ChainAbstractionClientImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+      raw as List<dynamic>,
+    );
   }
 
   @protected
   Address
-      dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
-          dynamic raw) {
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
+    dynamic raw,
+  ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return AddressImpl.frbInternalDcoDecode(raw as List<dynamic>);
   }
 
   @protected
   Call
-      dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
-          dynamic raw) {
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
+    dynamic raw,
+  ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return CallImpl.frbInternalDcoDecode(raw as List<dynamic>);
   }
 
   @protected
   ChainAbstractionClient
-      dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-          dynamic raw) {
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+    dynamic raw,
+  ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ChainAbstractionClientImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+      raw as List<dynamic>,
+    );
   }
 
   @protected
   Currency
-      dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
-          dynamic raw) {
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
+    dynamic raw,
+  ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return CurrencyImpl.frbInternalDcoDecode(raw as List<dynamic>);
   }
 
   @protected
   PrepareResponse
-      dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
-          dynamic raw) {
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
+    dynamic raw,
+  ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return PrepareResponseImpl.frbInternalDcoDecode(raw as List<dynamic>);
   }
 
   @protected
   PrepareResponseAvailable
-      dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
-          dynamic raw) {
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
+    dynamic raw,
+  ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return PrepareResponseAvailableImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+      raw as List<dynamic>,
+    );
   }
 
   @protected
   PulseMetadata
-      dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
-          dynamic raw) {
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
+    dynamic raw,
+  ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return PulseMetadataImpl.frbInternalDcoDecode(raw as List<dynamic>);
   }
 
   @protected
   StatusResponse
-      dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
-          dynamic raw) {
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
+    dynamic raw,
+  ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StatusResponseImpl.frbInternalDcoDecode(raw as List<dynamic>);
   }
 
   @protected
   StatusResponseCompleted
-      dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
-          dynamic raw) {
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
+    dynamic raw,
+  ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StatusResponseCompletedImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+      raw as List<dynamic>,
+    );
   }
 
   @protected
   UiFields
-      dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
-          dynamic raw) {
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
+    dynamic raw,
+  ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return UiFieldsImpl.frbInternalDcoDecode(raw as List<dynamic>);
   }
@@ -788,9 +1040,7 @@ class YttriumDartApiImpl extends YttriumDartApiImplPlatform
     // Codec=Dco (DartCObject based), see doc to use other codecs
     switch (raw[0]) {
       case 0:
-        return Error_General(
-          dco_decode_String(raw[1]),
-        );
+        return Error_General(dco_decode_String(raw[1]));
       default:
         throw Exception('unreachable');
     }
@@ -803,9 +1053,55 @@ class YttriumDartApiImpl extends YttriumDartApiImplPlatform
   }
 
   @protected
+  List<int> dco_decode_list_prim_u_8_loose(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as List<int>;
+  }
+
+  @protected
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as Uint8List;
+  }
+
+  @protected
+  List<SolanaSignedTransactionDart>
+  dco_decode_list_solana_signed_transaction_dart(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>)
+        .map(dco_decode_solana_signed_transaction_dart)
+        .toList();
+  }
+
+  @protected
+  SolanaSignError dco_decode_solana_sign_error(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    switch (raw[0]) {
+      case 0:
+        return SolanaSignError_InvalidKeypair(dco_decode_String(raw[1]));
+      case 1:
+        return SolanaSignError_InvalidTransaction(dco_decode_String(raw[1]));
+      case 2:
+        return SolanaSignError_SignerNotRequired(
+          pubkey: dco_decode_String(raw[1]),
+        );
+      default:
+        throw Exception('unreachable');
+    }
+  }
+
+  @protected
+  SolanaSignedTransactionDart dco_decode_solana_signed_transaction_dart(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return SolanaSignedTransactionDart(
+      signature: dco_decode_String(arr[0]),
+      transaction: dco_decode_String(arr[1]),
+    );
   }
 
   @protected
@@ -834,200 +1130,266 @@ class YttriumDartApiImpl extends YttriumDartApiImplPlatform
 
   @protected
   Address
-      sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
-          SseDeserializer deserializer) {
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
+    SseDeserializer deserializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return AddressImpl.frbInternalSseDecode(
-        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
   }
 
   @protected
   Call
-      sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
-          SseDeserializer deserializer) {
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
+    SseDeserializer deserializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return CallImpl.frbInternalSseDecode(
-        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
   }
 
   @protected
   ChainAbstractionClient
-      sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-          SseDeserializer deserializer) {
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+    SseDeserializer deserializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return ChainAbstractionClientImpl.frbInternalSseDecode(
-        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
   }
 
   @protected
   Currency
-      sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
-          SseDeserializer deserializer) {
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
+    SseDeserializer deserializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return CurrencyImpl.frbInternalSseDecode(
-        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
   }
 
   @protected
   PrepareResponse
-      sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
-          SseDeserializer deserializer) {
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
+    SseDeserializer deserializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return PrepareResponseImpl.frbInternalSseDecode(
-        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
   }
 
   @protected
   PrepareResponseAvailable
-      sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
-          SseDeserializer deserializer) {
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
+    SseDeserializer deserializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return PrepareResponseAvailableImpl.frbInternalSseDecode(
-        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
   }
 
   @protected
   PulseMetadata
-      sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
-          SseDeserializer deserializer) {
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
+    SseDeserializer deserializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return PulseMetadataImpl.frbInternalSseDecode(
-        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
   }
 
   @protected
   StatusResponse
-      sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
-          SseDeserializer deserializer) {
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
+    SseDeserializer deserializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return StatusResponseImpl.frbInternalSseDecode(
-        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
   }
 
   @protected
   StatusResponseCompleted
-      sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
-          SseDeserializer deserializer) {
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
+    SseDeserializer deserializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return StatusResponseCompletedImpl.frbInternalSseDecode(
-        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
   }
 
   @protected
   UiFields
-      sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
-          SseDeserializer deserializer) {
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
+    SseDeserializer deserializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return UiFieldsImpl.frbInternalSseDecode(
-        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
   }
 
   @protected
   ChainAbstractionClient
-      sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-          SseDeserializer deserializer) {
+  sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+    SseDeserializer deserializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return ChainAbstractionClientImpl.frbInternalSseDecode(
-        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
   }
 
   @protected
   ChainAbstractionClient
-      sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-          SseDeserializer deserializer) {
+  sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+    SseDeserializer deserializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return ChainAbstractionClientImpl.frbInternalSseDecode(
-        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
   }
 
   @protected
   Address
-      sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
-          SseDeserializer deserializer) {
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
+    SseDeserializer deserializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return AddressImpl.frbInternalSseDecode(
-        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
   }
 
   @protected
   Call
-      sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
-          SseDeserializer deserializer) {
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
+    SseDeserializer deserializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return CallImpl.frbInternalSseDecode(
-        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
   }
 
   @protected
   ChainAbstractionClient
-      sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-          SseDeserializer deserializer) {
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+    SseDeserializer deserializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return ChainAbstractionClientImpl.frbInternalSseDecode(
-        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
   }
 
   @protected
   Currency
-      sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
-          SseDeserializer deserializer) {
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
+    SseDeserializer deserializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return CurrencyImpl.frbInternalSseDecode(
-        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
   }
 
   @protected
   PrepareResponse
-      sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
-          SseDeserializer deserializer) {
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
+    SseDeserializer deserializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return PrepareResponseImpl.frbInternalSseDecode(
-        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
   }
 
   @protected
   PrepareResponseAvailable
-      sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
-          SseDeserializer deserializer) {
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
+    SseDeserializer deserializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return PrepareResponseAvailableImpl.frbInternalSseDecode(
-        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
   }
 
   @protected
   PulseMetadata
-      sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
-          SseDeserializer deserializer) {
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
+    SseDeserializer deserializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return PulseMetadataImpl.frbInternalSseDecode(
-        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
   }
 
   @protected
   StatusResponse
-      sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
-          SseDeserializer deserializer) {
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
+    SseDeserializer deserializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return StatusResponseImpl.frbInternalSseDecode(
-        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
   }
 
   @protected
   StatusResponseCompleted
-      sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
-          SseDeserializer deserializer) {
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
+    SseDeserializer deserializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return StatusResponseCompletedImpl.frbInternalSseDecode(
-        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
   }
 
   @protected
   UiFields
-      sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
-          SseDeserializer deserializer) {
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
+    SseDeserializer deserializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return UiFieldsImpl.frbInternalSseDecode(
-        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
   }
 
   @protected
@@ -1045,13 +1407,15 @@ class YttriumDartApiImpl extends YttriumDartApiImplPlatform
 
   @protected
   Eip1559Estimation sse_decode_eip_1559_estimation(
-      SseDeserializer deserializer) {
+    SseDeserializer deserializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_maxFeePerGas = sse_decode_String(deserializer);
     var var_maxPriorityFeePerGas = sse_decode_String(deserializer);
     return Eip1559Estimation(
-        maxFeePerGas: var_maxFeePerGas,
-        maxPriorityFeePerGas: var_maxPriorityFeePerGas);
+      maxFeePerGas: var_maxFeePerGas,
+      maxPriorityFeePerGas: var_maxPriorityFeePerGas,
+    );
   }
 
   @protected
@@ -1081,10 +1445,63 @@ class YttriumDartApiImpl extends YttriumDartApiImplPlatform
   }
 
   @protected
+  List<int> sse_decode_list_prim_u_8_loose(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var len_ = sse_decode_i_32(deserializer);
+    return deserializer.buffer.getUint8List(len_);
+  }
+
+  @protected
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var len_ = sse_decode_i_32(deserializer);
     return deserializer.buffer.getUint8List(len_);
+  }
+
+  @protected
+  List<SolanaSignedTransactionDart>
+  sse_decode_list_solana_signed_transaction_dart(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <SolanaSignedTransactionDart>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_solana_signed_transaction_dart(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  SolanaSignError sse_decode_solana_sign_error(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var tag_ = sse_decode_i_32(deserializer);
+    switch (tag_) {
+      case 0:
+        var var_field0 = sse_decode_String(deserializer);
+        return SolanaSignError_InvalidKeypair(var_field0);
+      case 1:
+        var var_field0 = sse_decode_String(deserializer);
+        return SolanaSignError_InvalidTransaction(var_field0);
+      case 2:
+        var var_pubkey = sse_decode_String(deserializer);
+        return SolanaSignError_SignerNotRequired(pubkey: var_pubkey);
+      default:
+        throw UnimplementedError('');
+    }
+  }
+
+  @protected
+  SolanaSignedTransactionDart sse_decode_solana_signed_transaction_dart(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_signature = sse_decode_String(deserializer);
+    var var_transaction = sse_decode_String(deserializer);
+    return SolanaSignedTransactionDart(
+      signature: var_signature,
+      transaction: var_transaction,
+    );
   }
 
   @protected
@@ -1118,214 +1535,288 @@ class YttriumDartApiImpl extends YttriumDartApiImplPlatform
 
   @protected
   void
-      sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
-          Address self, SseSerializer serializer) {
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
+    Address self,
+    SseSerializer serializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
-        (self as AddressImpl).frbInternalSseEncode(move: true), serializer);
+      (self as AddressImpl).frbInternalSseEncode(move: true),
+      serializer,
+    );
   }
 
   @protected
   void
-      sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
-          Call self, SseSerializer serializer) {
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
+    Call self,
+    SseSerializer serializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
-        (self as CallImpl).frbInternalSseEncode(move: true), serializer);
+      (self as CallImpl).frbInternalSseEncode(move: true),
+      serializer,
+    );
   }
 
   @protected
   void
-      sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-          ChainAbstractionClient self, SseSerializer serializer) {
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+    ChainAbstractionClient self,
+    SseSerializer serializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
-        (self as ChainAbstractionClientImpl).frbInternalSseEncode(move: true),
-        serializer);
+      (self as ChainAbstractionClientImpl).frbInternalSseEncode(move: true),
+      serializer,
+    );
   }
 
   @protected
   void
-      sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
-          Currency self, SseSerializer serializer) {
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
+    Currency self,
+    SseSerializer serializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
-        (self as CurrencyImpl).frbInternalSseEncode(move: true), serializer);
+      (self as CurrencyImpl).frbInternalSseEncode(move: true),
+      serializer,
+    );
   }
 
   @protected
   void
-      sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
-          PrepareResponse self, SseSerializer serializer) {
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
+    PrepareResponse self,
+    SseSerializer serializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
-        (self as PrepareResponseImpl).frbInternalSseEncode(move: true),
-        serializer);
+      (self as PrepareResponseImpl).frbInternalSseEncode(move: true),
+      serializer,
+    );
   }
 
   @protected
   void
-      sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
-          PrepareResponseAvailable self, SseSerializer serializer) {
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
+    PrepareResponseAvailable self,
+    SseSerializer serializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
-        (self as PrepareResponseAvailableImpl).frbInternalSseEncode(move: true),
-        serializer);
+      (self as PrepareResponseAvailableImpl).frbInternalSseEncode(move: true),
+      serializer,
+    );
   }
 
   @protected
   void
-      sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
-          PulseMetadata self, SseSerializer serializer) {
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
+    PulseMetadata self,
+    SseSerializer serializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
-        (self as PulseMetadataImpl).frbInternalSseEncode(move: true),
-        serializer);
+      (self as PulseMetadataImpl).frbInternalSseEncode(move: true),
+      serializer,
+    );
   }
 
   @protected
   void
-      sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
-          StatusResponse self, SseSerializer serializer) {
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
+    StatusResponse self,
+    SseSerializer serializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
-        (self as StatusResponseImpl).frbInternalSseEncode(move: true),
-        serializer);
+      (self as StatusResponseImpl).frbInternalSseEncode(move: true),
+      serializer,
+    );
   }
 
   @protected
   void
-      sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
-          StatusResponseCompleted self, SseSerializer serializer) {
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
+    StatusResponseCompleted self,
+    SseSerializer serializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
-        (self as StatusResponseCompletedImpl).frbInternalSseEncode(move: true),
-        serializer);
+      (self as StatusResponseCompletedImpl).frbInternalSseEncode(move: true),
+      serializer,
+    );
   }
 
   @protected
   void
-      sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
-          UiFields self, SseSerializer serializer) {
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
+    UiFields self,
+    SseSerializer serializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
-        (self as UiFieldsImpl).frbInternalSseEncode(move: true), serializer);
+      (self as UiFieldsImpl).frbInternalSseEncode(move: true),
+      serializer,
+    );
   }
 
   @protected
   void
-      sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-          ChainAbstractionClient self, SseSerializer serializer) {
+  sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+    ChainAbstractionClient self,
+    SseSerializer serializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
-        (self as ChainAbstractionClientImpl).frbInternalSseEncode(move: false),
-        serializer);
+      (self as ChainAbstractionClientImpl).frbInternalSseEncode(move: false),
+      serializer,
+    );
   }
 
   @protected
   void
-      sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-          ChainAbstractionClient self, SseSerializer serializer) {
+  sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+    ChainAbstractionClient self,
+    SseSerializer serializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
-        (self as ChainAbstractionClientImpl).frbInternalSseEncode(move: false),
-        serializer);
+      (self as ChainAbstractionClientImpl).frbInternalSseEncode(move: false),
+      serializer,
+    );
   }
 
   @protected
   void
-      sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
-          Address self, SseSerializer serializer) {
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
+    Address self,
+    SseSerializer serializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
-        (self as AddressImpl).frbInternalSseEncode(move: null), serializer);
+      (self as AddressImpl).frbInternalSseEncode(move: null),
+      serializer,
+    );
   }
 
   @protected
   void
-      sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
-          Call self, SseSerializer serializer) {
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
+    Call self,
+    SseSerializer serializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
-        (self as CallImpl).frbInternalSseEncode(move: null), serializer);
+      (self as CallImpl).frbInternalSseEncode(move: null),
+      serializer,
+    );
   }
 
   @protected
   void
-      sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-          ChainAbstractionClient self, SseSerializer serializer) {
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+    ChainAbstractionClient self,
+    SseSerializer serializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
-        (self as ChainAbstractionClientImpl).frbInternalSseEncode(move: null),
-        serializer);
+      (self as ChainAbstractionClientImpl).frbInternalSseEncode(move: null),
+      serializer,
+    );
   }
 
   @protected
   void
-      sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
-          Currency self, SseSerializer serializer) {
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
+    Currency self,
+    SseSerializer serializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
-        (self as CurrencyImpl).frbInternalSseEncode(move: null), serializer);
+      (self as CurrencyImpl).frbInternalSseEncode(move: null),
+      serializer,
+    );
   }
 
   @protected
   void
-      sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
-          PrepareResponse self, SseSerializer serializer) {
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
+    PrepareResponse self,
+    SseSerializer serializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
-        (self as PrepareResponseImpl).frbInternalSseEncode(move: null),
-        serializer);
+      (self as PrepareResponseImpl).frbInternalSseEncode(move: null),
+      serializer,
+    );
   }
 
   @protected
   void
-      sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
-          PrepareResponseAvailable self, SseSerializer serializer) {
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
+    PrepareResponseAvailable self,
+    SseSerializer serializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
-        (self as PrepareResponseAvailableImpl).frbInternalSseEncode(move: null),
-        serializer);
+      (self as PrepareResponseAvailableImpl).frbInternalSseEncode(move: null),
+      serializer,
+    );
   }
 
   @protected
   void
-      sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
-          PulseMetadata self, SseSerializer serializer) {
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
+    PulseMetadata self,
+    SseSerializer serializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
-        (self as PulseMetadataImpl).frbInternalSseEncode(move: null),
-        serializer);
+      (self as PulseMetadataImpl).frbInternalSseEncode(move: null),
+      serializer,
+    );
   }
 
   @protected
   void
-      sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
-          StatusResponse self, SseSerializer serializer) {
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
+    StatusResponse self,
+    SseSerializer serializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
-        (self as StatusResponseImpl).frbInternalSseEncode(move: null),
-        serializer);
+      (self as StatusResponseImpl).frbInternalSseEncode(move: null),
+      serializer,
+    );
   }
 
   @protected
   void
-      sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
-          StatusResponseCompleted self, SseSerializer serializer) {
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
+    StatusResponseCompleted self,
+    SseSerializer serializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
-        (self as StatusResponseCompletedImpl).frbInternalSseEncode(move: null),
-        serializer);
+      (self as StatusResponseCompletedImpl).frbInternalSseEncode(move: null),
+      serializer,
+    );
   }
 
   @protected
   void
-      sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
-          UiFields self, SseSerializer serializer) {
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
+    UiFields self,
+    SseSerializer serializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
-        (self as UiFieldsImpl).frbInternalSseEncode(move: null), serializer);
+      (self as UiFieldsImpl).frbInternalSseEncode(move: null),
+      serializer,
+    );
   }
 
   @protected
@@ -1342,7 +1833,9 @@ class YttriumDartApiImpl extends YttriumDartApiImplPlatform
 
   @protected
   void sse_encode_eip_1559_estimation(
-      Eip1559Estimation self, SseSerializer serializer) {
+    Eip1559Estimation self,
+    SseSerializer serializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.maxFeePerGas, serializer);
     sse_encode_String(self.maxPriorityFeePerGas, serializer);
@@ -1368,11 +1861,66 @@ class YttriumDartApiImpl extends YttriumDartApiImplPlatform
   }
 
   @protected
+  void sse_encode_list_prim_u_8_loose(
+    List<int> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    serializer.buffer.putUint8List(
+      self is Uint8List ? self : Uint8List.fromList(self),
+    );
+  }
+
+  @protected
   void sse_encode_list_prim_u_8_strict(
-      Uint8List self, SseSerializer serializer) {
+    Uint8List self,
+    SseSerializer serializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_i_32(self.length, serializer);
     serializer.buffer.putUint8List(self);
+  }
+
+  @protected
+  void sse_encode_list_solana_signed_transaction_dart(
+    List<SolanaSignedTransactionDart> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_solana_signed_transaction_dart(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_solana_sign_error(
+    SolanaSignError self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    switch (self) {
+      case SolanaSignError_InvalidKeypair(field0: final field0):
+        sse_encode_i_32(0, serializer);
+        sse_encode_String(field0, serializer);
+      case SolanaSignError_InvalidTransaction(field0: final field0):
+        sse_encode_i_32(1, serializer);
+        sse_encode_String(field0, serializer);
+      case SolanaSignError_SignerNotRequired(pubkey: final pubkey):
+        sse_encode_i_32(2, serializer);
+        sse_encode_String(pubkey, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_solana_signed_transaction_dart(
+    SolanaSignedTransactionDart self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.signature, serializer);
+    sse_encode_String(self.transaction, serializer);
   }
 
   @protected
@@ -1409,11 +1957,11 @@ class YttriumDartApiImpl extends YttriumDartApiImplPlatform
 class AddressImpl extends RustOpaque implements Address {
   // Not to be used by end users
   AddressImpl.frbInternalDcoDecode(List<dynamic> wire)
-      : super.frbInternalDcoDecode(wire, _kStaticData);
+    : super.frbInternalDcoDecode(wire, _kStaticData);
 
   // Not to be used by end users
   AddressImpl.frbInternalSseDecode(BigInt ptr, int externalSizeOnNative)
-      : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
+    : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
     rustArcIncrementStrongCount:
@@ -1429,11 +1977,11 @@ class AddressImpl extends RustOpaque implements Address {
 class CallImpl extends RustOpaque implements Call {
   // Not to be used by end users
   CallImpl.frbInternalDcoDecode(List<dynamic> wire)
-      : super.frbInternalDcoDecode(wire, _kStaticData);
+    : super.frbInternalDcoDecode(wire, _kStaticData);
 
   // Not to be used by end users
   CallImpl.frbInternalSseDecode(BigInt ptr, int externalSizeOnNative)
-      : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
+    : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
     rustArcIncrementStrongCount:
@@ -1450,87 +1998,107 @@ class ChainAbstractionClientImpl extends RustOpaque
     implements ChainAbstractionClient {
   // Not to be used by end users
   ChainAbstractionClientImpl.frbInternalDcoDecode(List<dynamic> wire)
-      : super.frbInternalDcoDecode(wire, _kStaticData);
+    : super.frbInternalDcoDecode(wire, _kStaticData);
 
   // Not to be used by end users
   ChainAbstractionClientImpl.frbInternalSseDecode(
-      BigInt ptr, int externalSizeOnNative)
-      : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
+    BigInt ptr,
+    int externalSizeOnNative,
+  ) : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
     rustArcIncrementStrongCount: YttriumDart
-        .instance.api.rust_arc_increment_strong_count_ChainAbstractionClient,
+        .instance
+        .api
+        .rust_arc_increment_strong_count_ChainAbstractionClient,
     rustArcDecrementStrongCount: YttriumDart
-        .instance.api.rust_arc_decrement_strong_count_ChainAbstractionClient,
+        .instance
+        .api
+        .rust_arc_decrement_strong_count_ChainAbstractionClient,
     rustArcDecrementStrongCountPtr: YttriumDart
-        .instance.api.rust_arc_decrement_strong_count_ChainAbstractionClientPtr,
+        .instance
+        .api
+        .rust_arc_decrement_strong_count_ChainAbstractionClientPtr,
   );
 
   String get projectId => YttriumDart.instance.api
-          .crateChainAbstractionClientAutoAccessorGetProjectId(
-        that: this,
-      );
+      .crateChainAbstractionClientAutoAccessorGetProjectId(that: this);
 
   set projectId(String projectId) => YttriumDart.instance.api
       .crateChainAbstractionClientAutoAccessorSetProjectId(
-          that: this, projectId: projectId);
+        that: this,
+        projectId: projectId,
+      );
 
-  Future<String> erc20TokenBalance(
-          {required String chainId,
-          required Address token,
-          required Address owner}) =>
-      YttriumDart.instance.api.crateChainAbstractionClientErc20TokenBalance(
-          that: this, chainId: chainId, token: token, owner: owner);
+  Future<String> erc20TokenBalance({
+    required String chainId,
+    required Address token,
+    required Address owner,
+  }) => YttriumDart.instance.api.crateChainAbstractionClientErc20TokenBalance(
+    that: this,
+    chainId: chainId,
+    token: token,
+    owner: owner,
+  );
 
   Future<Eip1559Estimation> estimateFees({required String chainId}) =>
       YttriumDart.instance.api.crateChainAbstractionClientEstimateFees(
-          that: this, chainId: chainId);
+        that: this,
+        chainId: chainId,
+      );
 
-  Future<UiFields> getUiFields(
-          {required PrepareResponseAvailable routeResponse,
-          required Currency currency}) =>
-      YttriumDart.instance.api.crateChainAbstractionClientGetUiFields(
-          that: this, routeResponse: routeResponse, currency: currency);
+  Future<UiFields> getUiFields({
+    required PrepareResponseAvailable routeResponse,
+    required Currency currency,
+  }) => YttriumDart.instance.api.crateChainAbstractionClientGetUiFields(
+    that: this,
+    routeResponse: routeResponse,
+    currency: currency,
+  );
 
-  Future<PrepareResponse> prepare(
-          {required String chainId,
-          required Address from,
-          required Call call,
-          required List<String> accounts,
-          required bool useLifi}) =>
-      YttriumDart.instance.api.crateChainAbstractionClientPrepare(
-          that: this,
-          chainId: chainId,
-          from: from,
-          call: call,
-          accounts: accounts,
-          useLifi: useLifi);
+  Future<PrepareResponse> prepare({
+    required String chainId,
+    required Address from,
+    required Call call,
+    required List<String> accounts,
+    required bool useLifi,
+  }) => YttriumDart.instance.api.crateChainAbstractionClientPrepare(
+    that: this,
+    chainId: chainId,
+    from: from,
+    call: call,
+    accounts: accounts,
+    useLifi: useLifi,
+  );
 
   Future<StatusResponse> status({required String orchestrationId}) =>
       YttriumDart.instance.api.crateChainAbstractionClientStatus(
-          that: this, orchestrationId: orchestrationId);
+        that: this,
+        orchestrationId: orchestrationId,
+      );
 
-  Future<StatusResponseCompleted> waitForSuccessWithTimeout(
-          {required String orchestrationId,
-          required BigInt checkIn,
-          required BigInt timeout}) =>
-      YttriumDart.instance.api
-          .crateChainAbstractionClientWaitForSuccessWithTimeout(
-              that: this,
-              orchestrationId: orchestrationId,
-              checkIn: checkIn,
-              timeout: timeout);
+  Future<StatusResponseCompleted> waitForSuccessWithTimeout({
+    required String orchestrationId,
+    required BigInt checkIn,
+    required BigInt timeout,
+  }) => YttriumDart.instance.api
+      .crateChainAbstractionClientWaitForSuccessWithTimeout(
+        that: this,
+        orchestrationId: orchestrationId,
+        checkIn: checkIn,
+        timeout: timeout,
+      );
 }
 
 @sealed
 class CurrencyImpl extends RustOpaque implements Currency {
   // Not to be used by end users
   CurrencyImpl.frbInternalDcoDecode(List<dynamic> wire)
-      : super.frbInternalDcoDecode(wire, _kStaticData);
+    : super.frbInternalDcoDecode(wire, _kStaticData);
 
   // Not to be used by end users
   CurrencyImpl.frbInternalSseDecode(BigInt ptr, int externalSizeOnNative)
-      : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
+    : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
     rustArcIncrementStrongCount:
@@ -1547,19 +2115,26 @@ class PrepareResponseAvailableImpl extends RustOpaque
     implements PrepareResponseAvailable {
   // Not to be used by end users
   PrepareResponseAvailableImpl.frbInternalDcoDecode(List<dynamic> wire)
-      : super.frbInternalDcoDecode(wire, _kStaticData);
+    : super.frbInternalDcoDecode(wire, _kStaticData);
 
   // Not to be used by end users
   PrepareResponseAvailableImpl.frbInternalSseDecode(
-      BigInt ptr, int externalSizeOnNative)
-      : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
+    BigInt ptr,
+    int externalSizeOnNative,
+  ) : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
     rustArcIncrementStrongCount: YttriumDart
-        .instance.api.rust_arc_increment_strong_count_PrepareResponseAvailable,
+        .instance
+        .api
+        .rust_arc_increment_strong_count_PrepareResponseAvailable,
     rustArcDecrementStrongCount: YttriumDart
-        .instance.api.rust_arc_decrement_strong_count_PrepareResponseAvailable,
-    rustArcDecrementStrongCountPtr: YttriumDart.instance.api
+        .instance
+        .api
+        .rust_arc_decrement_strong_count_PrepareResponseAvailable,
+    rustArcDecrementStrongCountPtr: YttriumDart
+        .instance
+        .api
         .rust_arc_decrement_strong_count_PrepareResponseAvailablePtr,
   );
 }
@@ -1568,19 +2143,25 @@ class PrepareResponseAvailableImpl extends RustOpaque
 class PrepareResponseImpl extends RustOpaque implements PrepareResponse {
   // Not to be used by end users
   PrepareResponseImpl.frbInternalDcoDecode(List<dynamic> wire)
-      : super.frbInternalDcoDecode(wire, _kStaticData);
+    : super.frbInternalDcoDecode(wire, _kStaticData);
 
   // Not to be used by end users
   PrepareResponseImpl.frbInternalSseDecode(BigInt ptr, int externalSizeOnNative)
-      : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
+    : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
     rustArcIncrementStrongCount: YttriumDart
-        .instance.api.rust_arc_increment_strong_count_PrepareResponse,
+        .instance
+        .api
+        .rust_arc_increment_strong_count_PrepareResponse,
     rustArcDecrementStrongCount: YttriumDart
-        .instance.api.rust_arc_decrement_strong_count_PrepareResponse,
+        .instance
+        .api
+        .rust_arc_decrement_strong_count_PrepareResponse,
     rustArcDecrementStrongCountPtr: YttriumDart
-        .instance.api.rust_arc_decrement_strong_count_PrepareResponsePtr,
+        .instance
+        .api
+        .rust_arc_decrement_strong_count_PrepareResponsePtr,
   );
 }
 
@@ -1588,11 +2169,11 @@ class PrepareResponseImpl extends RustOpaque implements PrepareResponse {
 class PulseMetadataImpl extends RustOpaque implements PulseMetadata {
   // Not to be used by end users
   PulseMetadataImpl.frbInternalDcoDecode(List<dynamic> wire)
-      : super.frbInternalDcoDecode(wire, _kStaticData);
+    : super.frbInternalDcoDecode(wire, _kStaticData);
 
   // Not to be used by end users
   PulseMetadataImpl.frbInternalSseDecode(BigInt ptr, int externalSizeOnNative)
-      : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
+    : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
     rustArcIncrementStrongCount:
@@ -1600,7 +2181,9 @@ class PulseMetadataImpl extends RustOpaque implements PulseMetadata {
     rustArcDecrementStrongCount:
         YttriumDart.instance.api.rust_arc_decrement_strong_count_PulseMetadata,
     rustArcDecrementStrongCountPtr: YttriumDart
-        .instance.api.rust_arc_decrement_strong_count_PulseMetadataPtr,
+        .instance
+        .api
+        .rust_arc_decrement_strong_count_PulseMetadataPtr,
   );
 }
 
@@ -1609,19 +2192,26 @@ class StatusResponseCompletedImpl extends RustOpaque
     implements StatusResponseCompleted {
   // Not to be used by end users
   StatusResponseCompletedImpl.frbInternalDcoDecode(List<dynamic> wire)
-      : super.frbInternalDcoDecode(wire, _kStaticData);
+    : super.frbInternalDcoDecode(wire, _kStaticData);
 
   // Not to be used by end users
   StatusResponseCompletedImpl.frbInternalSseDecode(
-      BigInt ptr, int externalSizeOnNative)
-      : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
+    BigInt ptr,
+    int externalSizeOnNative,
+  ) : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
     rustArcIncrementStrongCount: YttriumDart
-        .instance.api.rust_arc_increment_strong_count_StatusResponseCompleted,
+        .instance
+        .api
+        .rust_arc_increment_strong_count_StatusResponseCompleted,
     rustArcDecrementStrongCount: YttriumDart
-        .instance.api.rust_arc_decrement_strong_count_StatusResponseCompleted,
-    rustArcDecrementStrongCountPtr: YttriumDart.instance.api
+        .instance
+        .api
+        .rust_arc_decrement_strong_count_StatusResponseCompleted,
+    rustArcDecrementStrongCountPtr: YttriumDart
+        .instance
+        .api
         .rust_arc_decrement_strong_count_StatusResponseCompletedPtr,
   );
 }
@@ -1630,11 +2220,11 @@ class StatusResponseCompletedImpl extends RustOpaque
 class StatusResponseImpl extends RustOpaque implements StatusResponse {
   // Not to be used by end users
   StatusResponseImpl.frbInternalDcoDecode(List<dynamic> wire)
-      : super.frbInternalDcoDecode(wire, _kStaticData);
+    : super.frbInternalDcoDecode(wire, _kStaticData);
 
   // Not to be used by end users
   StatusResponseImpl.frbInternalSseDecode(BigInt ptr, int externalSizeOnNative)
-      : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
+    : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
     rustArcIncrementStrongCount:
@@ -1642,7 +2232,9 @@ class StatusResponseImpl extends RustOpaque implements StatusResponse {
     rustArcDecrementStrongCount:
         YttriumDart.instance.api.rust_arc_decrement_strong_count_StatusResponse,
     rustArcDecrementStrongCountPtr: YttriumDart
-        .instance.api.rust_arc_decrement_strong_count_StatusResponsePtr,
+        .instance
+        .api
+        .rust_arc_decrement_strong_count_StatusResponsePtr,
   );
 }
 
@@ -1650,11 +2242,11 @@ class StatusResponseImpl extends RustOpaque implements StatusResponse {
 class UiFieldsImpl extends RustOpaque implements UiFields {
   // Not to be used by end users
   UiFieldsImpl.frbInternalDcoDecode(List<dynamic> wire)
-      : super.frbInternalDcoDecode(wire, _kStaticData);
+    : super.frbInternalDcoDecode(wire, _kStaticData);
 
   // Not to be used by end users
   UiFieldsImpl.frbInternalSseDecode(BigInt ptr, int externalSizeOnNative)
-      : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
+    : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
     rustArcIncrementStrongCount:

--- a/crates/yttrium_dart/lib/generated/frb_generated.io.dart
+++ b/crates/yttrium_dart/lib/generated/frb_generated.io.dart
@@ -18,151 +18,176 @@ abstract class YttriumDartApiImplPlatform extends BaseApiImpl<YttriumDartWire> {
     required super.portManager,
   });
 
-  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_AddressPtr => wire
+  CrossPlatformFinalizerArg
+  get rust_arc_decrement_strong_count_AddressPtr => wire
       ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddressPtr;
 
   CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_CallPtr => wire
       ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCallPtr;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_ChainAbstractionClientPtr => wire
-          ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClientPtr;
+  get rust_arc_decrement_strong_count_ChainAbstractionClientPtr => wire
+      ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClientPtr;
 
-  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_CurrencyPtr => wire
+  CrossPlatformFinalizerArg
+  get rust_arc_decrement_strong_count_CurrencyPtr => wire
       ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrencyPtr;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_PrepareResponsePtr => wire
-          ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponsePtr;
+  get rust_arc_decrement_strong_count_PrepareResponsePtr => wire
+      ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponsePtr;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_PrepareResponseAvailablePtr => wire
-          ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailablePtr;
+  get rust_arc_decrement_strong_count_PrepareResponseAvailablePtr => wire
+      ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailablePtr;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_PulseMetadataPtr => wire
-          ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadataPtr;
+  get rust_arc_decrement_strong_count_PulseMetadataPtr => wire
+      ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadataPtr;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_StatusResponsePtr => wire
-          ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponsePtr;
+  get rust_arc_decrement_strong_count_StatusResponsePtr => wire
+      ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponsePtr;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_StatusResponseCompletedPtr => wire
-          ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompletedPtr;
+  get rust_arc_decrement_strong_count_StatusResponseCompletedPtr => wire
+      ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompletedPtr;
 
-  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_UiFieldsPtr => wire
+  CrossPlatformFinalizerArg
+  get rust_arc_decrement_strong_count_UiFieldsPtr => wire
       ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFieldsPtr;
 
   @protected
   Address
-      dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
-          dynamic raw);
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
+    dynamic raw,
+  );
 
   @protected
   Call
-      dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
-          dynamic raw);
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
+    dynamic raw,
+  );
 
   @protected
   ChainAbstractionClient
-      dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-          dynamic raw);
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+    dynamic raw,
+  );
 
   @protected
   Currency
-      dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
-          dynamic raw);
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
+    dynamic raw,
+  );
 
   @protected
   PrepareResponse
-      dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
-          dynamic raw);
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
+    dynamic raw,
+  );
 
   @protected
   PrepareResponseAvailable
-      dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
-          dynamic raw);
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
+    dynamic raw,
+  );
 
   @protected
   PulseMetadata
-      dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
-          dynamic raw);
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
+    dynamic raw,
+  );
 
   @protected
   StatusResponse
-      dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
-          dynamic raw);
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
+    dynamic raw,
+  );
 
   @protected
   StatusResponseCompleted
-      dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
-          dynamic raw);
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
+    dynamic raw,
+  );
 
   @protected
   UiFields
-      dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
-          dynamic raw);
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
+    dynamic raw,
+  );
 
   @protected
   ChainAbstractionClient
-      dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-          dynamic raw);
+  dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+    dynamic raw,
+  );
 
   @protected
   ChainAbstractionClient
-      dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-          dynamic raw);
+  dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+    dynamic raw,
+  );
 
   @protected
   Address
-      dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
-          dynamic raw);
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
+    dynamic raw,
+  );
 
   @protected
   Call
-      dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
-          dynamic raw);
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
+    dynamic raw,
+  );
 
   @protected
   ChainAbstractionClient
-      dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-          dynamic raw);
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+    dynamic raw,
+  );
 
   @protected
   Currency
-      dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
-          dynamic raw);
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
+    dynamic raw,
+  );
 
   @protected
   PrepareResponse
-      dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
-          dynamic raw);
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
+    dynamic raw,
+  );
 
   @protected
   PrepareResponseAvailable
-      dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
-          dynamic raw);
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
+    dynamic raw,
+  );
 
   @protected
   PulseMetadata
-      dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
-          dynamic raw);
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
+    dynamic raw,
+  );
 
   @protected
   StatusResponse
-      dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
-          dynamic raw);
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
+    dynamic raw,
+  );
 
   @protected
   StatusResponseCompleted
-      dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
-          dynamic raw);
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
+    dynamic raw,
+  );
 
   @protected
   UiFields
-      dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
-          dynamic raw);
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
+    dynamic raw,
+  );
 
   @protected
   String dco_decode_String(dynamic raw);
@@ -180,7 +205,22 @@ abstract class YttriumDartApiImplPlatform extends BaseApiImpl<YttriumDartWire> {
   List<String> dco_decode_list_String(dynamic raw);
 
   @protected
+  List<int> dco_decode_list_prim_u_8_loose(dynamic raw);
+
+  @protected
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
+
+  @protected
+  List<SolanaSignedTransactionDart>
+  dco_decode_list_solana_signed_transaction_dart(dynamic raw);
+
+  @protected
+  SolanaSignError dco_decode_solana_sign_error(dynamic raw);
+
+  @protected
+  SolanaSignedTransactionDart dco_decode_solana_signed_transaction_dart(
+    dynamic raw,
+  );
 
   @protected
   BigInt dco_decode_u_64(dynamic raw);
@@ -196,113 +236,135 @@ abstract class YttriumDartApiImplPlatform extends BaseApiImpl<YttriumDartWire> {
 
   @protected
   Address
-      sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
-          SseDeserializer deserializer);
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
+    SseDeserializer deserializer,
+  );
 
   @protected
   Call
-      sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
-          SseDeserializer deserializer);
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
+    SseDeserializer deserializer,
+  );
 
   @protected
   ChainAbstractionClient
-      sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-          SseDeserializer deserializer);
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+    SseDeserializer deserializer,
+  );
 
   @protected
   Currency
-      sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
-          SseDeserializer deserializer);
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
+    SseDeserializer deserializer,
+  );
 
   @protected
   PrepareResponse
-      sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
-          SseDeserializer deserializer);
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
+    SseDeserializer deserializer,
+  );
 
   @protected
   PrepareResponseAvailable
-      sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
-          SseDeserializer deserializer);
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
+    SseDeserializer deserializer,
+  );
 
   @protected
   PulseMetadata
-      sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
-          SseDeserializer deserializer);
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
+    SseDeserializer deserializer,
+  );
 
   @protected
   StatusResponse
-      sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
-          SseDeserializer deserializer);
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
+    SseDeserializer deserializer,
+  );
 
   @protected
   StatusResponseCompleted
-      sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
-          SseDeserializer deserializer);
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
+    SseDeserializer deserializer,
+  );
 
   @protected
   UiFields
-      sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
-          SseDeserializer deserializer);
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
+    SseDeserializer deserializer,
+  );
 
   @protected
   ChainAbstractionClient
-      sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-          SseDeserializer deserializer);
+  sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+    SseDeserializer deserializer,
+  );
 
   @protected
   ChainAbstractionClient
-      sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-          SseDeserializer deserializer);
+  sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+    SseDeserializer deserializer,
+  );
 
   @protected
   Address
-      sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
-          SseDeserializer deserializer);
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
+    SseDeserializer deserializer,
+  );
 
   @protected
   Call
-      sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
-          SseDeserializer deserializer);
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
+    SseDeserializer deserializer,
+  );
 
   @protected
   ChainAbstractionClient
-      sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-          SseDeserializer deserializer);
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+    SseDeserializer deserializer,
+  );
 
   @protected
   Currency
-      sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
-          SseDeserializer deserializer);
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
+    SseDeserializer deserializer,
+  );
 
   @protected
   PrepareResponse
-      sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
-          SseDeserializer deserializer);
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
+    SseDeserializer deserializer,
+  );
 
   @protected
   PrepareResponseAvailable
-      sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
-          SseDeserializer deserializer);
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
+    SseDeserializer deserializer,
+  );
 
   @protected
   PulseMetadata
-      sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
-          SseDeserializer deserializer);
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
+    SseDeserializer deserializer,
+  );
 
   @protected
   StatusResponse
-      sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
-          SseDeserializer deserializer);
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
+    SseDeserializer deserializer,
+  );
 
   @protected
   StatusResponseCompleted
-      sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
-          SseDeserializer deserializer);
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
+    SseDeserializer deserializer,
+  );
 
   @protected
   UiFields
-      sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
-          SseDeserializer deserializer);
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
+    SseDeserializer deserializer,
+  );
 
   @protected
   String sse_decode_String(SseDeserializer deserializer);
@@ -312,7 +374,8 @@ abstract class YttriumDartApiImplPlatform extends BaseApiImpl<YttriumDartWire> {
 
   @protected
   Eip1559Estimation sse_decode_eip_1559_estimation(
-      SseDeserializer deserializer);
+    SseDeserializer deserializer,
+  );
 
   @protected
   Error sse_decode_error(SseDeserializer deserializer);
@@ -321,7 +384,22 @@ abstract class YttriumDartApiImplPlatform extends BaseApiImpl<YttriumDartWire> {
   List<String> sse_decode_list_String(SseDeserializer deserializer);
 
   @protected
+  List<int> sse_decode_list_prim_u_8_loose(SseDeserializer deserializer);
+
+  @protected
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
+
+  @protected
+  List<SolanaSignedTransactionDart>
+  sse_decode_list_solana_signed_transaction_dart(SseDeserializer deserializer);
+
+  @protected
+  SolanaSignError sse_decode_solana_sign_error(SseDeserializer deserializer);
+
+  @protected
+  SolanaSignedTransactionDart sse_decode_solana_signed_transaction_dart(
+    SseDeserializer deserializer,
+  );
 
   @protected
   BigInt sse_decode_u_64(SseDeserializer deserializer);
@@ -340,113 +418,157 @@ abstract class YttriumDartApiImplPlatform extends BaseApiImpl<YttriumDartWire> {
 
   @protected
   void
-      sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
-          Address self, SseSerializer serializer);
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
+    Address self,
+    SseSerializer serializer,
+  );
 
   @protected
   void
-      sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
-          Call self, SseSerializer serializer);
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
+    Call self,
+    SseSerializer serializer,
+  );
 
   @protected
   void
-      sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-          ChainAbstractionClient self, SseSerializer serializer);
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+    ChainAbstractionClient self,
+    SseSerializer serializer,
+  );
 
   @protected
   void
-      sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
-          Currency self, SseSerializer serializer);
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
+    Currency self,
+    SseSerializer serializer,
+  );
 
   @protected
   void
-      sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
-          PrepareResponse self, SseSerializer serializer);
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
+    PrepareResponse self,
+    SseSerializer serializer,
+  );
 
   @protected
   void
-      sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
-          PrepareResponseAvailable self, SseSerializer serializer);
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
+    PrepareResponseAvailable self,
+    SseSerializer serializer,
+  );
 
   @protected
   void
-      sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
-          PulseMetadata self, SseSerializer serializer);
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
+    PulseMetadata self,
+    SseSerializer serializer,
+  );
 
   @protected
   void
-      sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
-          StatusResponse self, SseSerializer serializer);
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
+    StatusResponse self,
+    SseSerializer serializer,
+  );
 
   @protected
   void
-      sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
-          StatusResponseCompleted self, SseSerializer serializer);
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
+    StatusResponseCompleted self,
+    SseSerializer serializer,
+  );
 
   @protected
   void
-      sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
-          UiFields self, SseSerializer serializer);
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
+    UiFields self,
+    SseSerializer serializer,
+  );
 
   @protected
   void
-      sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-          ChainAbstractionClient self, SseSerializer serializer);
+  sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+    ChainAbstractionClient self,
+    SseSerializer serializer,
+  );
 
   @protected
   void
-      sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-          ChainAbstractionClient self, SseSerializer serializer);
+  sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+    ChainAbstractionClient self,
+    SseSerializer serializer,
+  );
 
   @protected
   void
-      sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
-          Address self, SseSerializer serializer);
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
+    Address self,
+    SseSerializer serializer,
+  );
 
   @protected
   void
-      sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
-          Call self, SseSerializer serializer);
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
+    Call self,
+    SseSerializer serializer,
+  );
 
   @protected
   void
-      sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
-          ChainAbstractionClient self, SseSerializer serializer);
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+    ChainAbstractionClient self,
+    SseSerializer serializer,
+  );
 
   @protected
   void
-      sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
-          Currency self, SseSerializer serializer);
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
+    Currency self,
+    SseSerializer serializer,
+  );
 
   @protected
   void
-      sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
-          PrepareResponse self, SseSerializer serializer);
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
+    PrepareResponse self,
+    SseSerializer serializer,
+  );
 
   @protected
   void
-      sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
-          PrepareResponseAvailable self, SseSerializer serializer);
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
+    PrepareResponseAvailable self,
+    SseSerializer serializer,
+  );
 
   @protected
   void
-      sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
-          PulseMetadata self, SseSerializer serializer);
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
+    PulseMetadata self,
+    SseSerializer serializer,
+  );
 
   @protected
   void
-      sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
-          StatusResponse self, SseSerializer serializer);
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
+    StatusResponse self,
+    SseSerializer serializer,
+  );
 
   @protected
   void
-      sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
-          StatusResponseCompleted self, SseSerializer serializer);
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
+    StatusResponseCompleted self,
+    SseSerializer serializer,
+  );
 
   @protected
   void
-      sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
-          UiFields self, SseSerializer serializer);
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
+    UiFields self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_String(String self, SseSerializer serializer);
@@ -456,7 +578,9 @@ abstract class YttriumDartApiImplPlatform extends BaseApiImpl<YttriumDartWire> {
 
   @protected
   void sse_encode_eip_1559_estimation(
-      Eip1559Estimation self, SseSerializer serializer);
+    Eip1559Estimation self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_error(Error self, SseSerializer serializer);
@@ -465,8 +589,31 @@ abstract class YttriumDartApiImplPlatform extends BaseApiImpl<YttriumDartWire> {
   void sse_encode_list_String(List<String> self, SseSerializer serializer);
 
   @protected
+  void sse_encode_list_prim_u_8_loose(List<int> self, SseSerializer serializer);
+
+  @protected
   void sse_encode_list_prim_u_8_strict(
-      Uint8List self, SseSerializer serializer);
+    Uint8List self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_list_solana_signed_transaction_dart(
+    List<SolanaSignedTransactionDart> self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_solana_sign_error(
+    SolanaSignError self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_solana_signed_transaction_dart(
+    SolanaSignedTransactionDart self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_u_64(BigInt self, SseSerializer serializer);
@@ -492,14 +639,14 @@ class YttriumDartWire implements BaseWire {
 
   /// Holds the symbol lookup function.
   final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
-      _lookup;
+  _lookup;
 
   /// The symbols are looked up in [dynamicLibrary].
   YttriumDartWire(ffi.DynamicLibrary dynamicLibrary)
-      : _lookup = dynamicLibrary.lookup;
+    : _lookup = dynamicLibrary.lookup;
 
   void
-      rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
+  rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
     ffi.Pointer<ffi.Void> ptr,
   ) {
     return _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
@@ -509,13 +656,14 @@ class YttriumDartWire implements BaseWire {
 
   late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddressPtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-          'frbgen_yttrium_dart_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress');
+        'frbgen_yttrium_dart_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress',
+      );
   late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress =
       _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddressPtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void
-      rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
+  rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
     ffi.Pointer<ffi.Void> ptr,
   ) {
     return _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress(
@@ -525,13 +673,14 @@ class YttriumDartWire implements BaseWire {
 
   late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddressPtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-          'frbgen_yttrium_dart_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress');
+        'frbgen_yttrium_dart_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress',
+      );
   late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddress =
       _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAddressPtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void
-      rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
+  rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
     ffi.Pointer<ffi.Void> ptr,
   ) {
     return _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
@@ -541,13 +690,14 @@ class YttriumDartWire implements BaseWire {
 
   late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCallPtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-          'frbgen_yttrium_dart_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall');
+        'frbgen_yttrium_dart_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall',
+      );
   late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall =
       _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCallPtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void
-      rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
+  rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
     ffi.Pointer<ffi.Void> ptr,
   ) {
     return _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall(
@@ -557,13 +707,14 @@ class YttriumDartWire implements BaseWire {
 
   late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCallPtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-          'frbgen_yttrium_dart_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall');
+        'frbgen_yttrium_dart_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall',
+      );
   late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCall =
       _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCallPtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void
-      rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+  rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
     ffi.Pointer<ffi.Void> ptr,
   ) {
     return _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
@@ -573,13 +724,14 @@ class YttriumDartWire implements BaseWire {
 
   late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClientPtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-          'frbgen_yttrium_dart_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient');
+        'frbgen_yttrium_dart_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient',
+      );
   late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient =
       _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClientPtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void
-      rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
+  rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
     ffi.Pointer<ffi.Void> ptr,
   ) {
     return _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient(
@@ -589,13 +741,14 @@ class YttriumDartWire implements BaseWire {
 
   late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClientPtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-          'frbgen_yttrium_dart_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient');
+        'frbgen_yttrium_dart_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient',
+      );
   late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClient =
       _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChainAbstractionClientPtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void
-      rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
+  rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
     ffi.Pointer<ffi.Void> ptr,
   ) {
     return _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
@@ -605,13 +758,14 @@ class YttriumDartWire implements BaseWire {
 
   late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrencyPtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-          'frbgen_yttrium_dart_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency');
+        'frbgen_yttrium_dart_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency',
+      );
   late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency =
       _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrencyPtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void
-      rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
+  rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
     ffi.Pointer<ffi.Void> ptr,
   ) {
     return _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency(
@@ -621,13 +775,14 @@ class YttriumDartWire implements BaseWire {
 
   late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrencyPtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-          'frbgen_yttrium_dart_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency');
+        'frbgen_yttrium_dart_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency',
+      );
   late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrency =
       _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCurrencyPtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void
-      rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
+  rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
     ffi.Pointer<ffi.Void> ptr,
   ) {
     return _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
@@ -637,13 +792,14 @@ class YttriumDartWire implements BaseWire {
 
   late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponsePtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-          'frbgen_yttrium_dart_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse');
+        'frbgen_yttrium_dart_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse',
+      );
   late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse =
       _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponsePtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void
-      rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
+  rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
     ffi.Pointer<ffi.Void> ptr,
   ) {
     return _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse(
@@ -653,13 +809,14 @@ class YttriumDartWire implements BaseWire {
 
   late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponsePtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-          'frbgen_yttrium_dart_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse');
+        'frbgen_yttrium_dart_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse',
+      );
   late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponse =
       _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponsePtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void
-      rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
+  rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
     ffi.Pointer<ffi.Void> ptr,
   ) {
     return _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
@@ -669,13 +826,14 @@ class YttriumDartWire implements BaseWire {
 
   late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailablePtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-          'frbgen_yttrium_dart_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable');
+        'frbgen_yttrium_dart_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable',
+      );
   late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable =
       _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailablePtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void
-      rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
+  rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
     ffi.Pointer<ffi.Void> ptr,
   ) {
     return _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable(
@@ -685,13 +843,14 @@ class YttriumDartWire implements BaseWire {
 
   late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailablePtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-          'frbgen_yttrium_dart_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable');
+        'frbgen_yttrium_dart_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable',
+      );
   late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailable =
       _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPrepareResponseAvailablePtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void
-      rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
+  rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
     ffi.Pointer<ffi.Void> ptr,
   ) {
     return _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
@@ -701,13 +860,14 @@ class YttriumDartWire implements BaseWire {
 
   late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadataPtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-          'frbgen_yttrium_dart_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata');
+        'frbgen_yttrium_dart_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata',
+      );
   late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata =
       _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadataPtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void
-      rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
+  rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
     ffi.Pointer<ffi.Void> ptr,
   ) {
     return _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata(
@@ -717,13 +877,14 @@ class YttriumDartWire implements BaseWire {
 
   late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadataPtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-          'frbgen_yttrium_dart_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata');
+        'frbgen_yttrium_dart_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata',
+      );
   late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadata =
       _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPulseMetadataPtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void
-      rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
+  rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
     ffi.Pointer<ffi.Void> ptr,
   ) {
     return _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
@@ -733,13 +894,14 @@ class YttriumDartWire implements BaseWire {
 
   late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponsePtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-          'frbgen_yttrium_dart_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse');
+        'frbgen_yttrium_dart_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse',
+      );
   late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse =
       _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponsePtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void
-      rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
+  rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
     ffi.Pointer<ffi.Void> ptr,
   ) {
     return _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse(
@@ -749,13 +911,14 @@ class YttriumDartWire implements BaseWire {
 
   late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponsePtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-          'frbgen_yttrium_dart_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse');
+        'frbgen_yttrium_dart_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse',
+      );
   late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponse =
       _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponsePtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void
-      rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
+  rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
     ffi.Pointer<ffi.Void> ptr,
   ) {
     return _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
@@ -765,13 +928,14 @@ class YttriumDartWire implements BaseWire {
 
   late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompletedPtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-          'frbgen_yttrium_dart_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted');
+        'frbgen_yttrium_dart_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted',
+      );
   late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted =
       _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompletedPtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void
-      rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
+  rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
     ffi.Pointer<ffi.Void> ptr,
   ) {
     return _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted(
@@ -781,13 +945,14 @@ class YttriumDartWire implements BaseWire {
 
   late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompletedPtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-          'frbgen_yttrium_dart_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted');
+        'frbgen_yttrium_dart_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted',
+      );
   late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompleted =
       _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStatusResponseCompletedPtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void
-      rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
+  rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
     ffi.Pointer<ffi.Void> ptr,
   ) {
     return _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
@@ -797,13 +962,14 @@ class YttriumDartWire implements BaseWire {
 
   late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFieldsPtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-          'frbgen_yttrium_dart_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields');
+        'frbgen_yttrium_dart_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields',
+      );
   late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields =
       _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFieldsPtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void
-      rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
+  rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
     ffi.Pointer<ffi.Void> ptr,
   ) {
     return _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields(
@@ -813,7 +979,8 @@ class YttriumDartWire implements BaseWire {
 
   late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFieldsPtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-          'frbgen_yttrium_dart_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields');
+        'frbgen_yttrium_dart_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields',
+      );
   late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFields =
       _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiFieldsPtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();

--- a/crates/yttrium_dart/lib/generated/lib.dart
+++ b/crates/yttrium_dart/lib/generated/lib.dart
@@ -8,8 +8,40 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 part 'lib.freezed.dart';
 
+// These functions are ignored because they are not marked as `pub`: `encode_signed_transaction`, `parse_solana_keypair`, `parse_solana_transaction`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `PreparedSignature`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `fmt`, `fmt`, `fmt`, `fmt`, `from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`
+
+/// Signs a Solana `VersionedTransaction` using the WalletConnect
+/// `solana_signTransaction` wire format (base64-bincode transaction,
+/// base58 keypair). Returns the signed transaction re-encoded as base64
+/// plus the base58 signature placed at the keypair's signer slot.
+Future<SolanaSignedTransactionDart> solanaSignTransaction({
+  required String keypairBase58,
+  required String transactionBase64,
+}) => YttriumDart.instance.api.crateSolanaSignTransaction(
+  keypairBase58: keypairBase58,
+  transactionBase64: transactionBase64,
+);
+
+/// Batched variant matching WalletConnect's `solana_signAllTransactions`.
+Future<List<SolanaSignedTransactionDart>> solanaSignAllTransactions({
+  required String keypairBase58,
+  required List<String> transactionsBase64,
+}) => YttriumDart.instance.api.crateSolanaSignAllTransactions(
+  keypairBase58: keypairBase58,
+  transactionsBase64: transactionsBase64,
+);
+
+/// Signs arbitrary bytes (WalletConnect's `solana_signMessage`). Returns
+/// the base58-encoded Ed25519 signature.
+Future<String> solanaSignMessage({
+  required String keypairBase58,
+  required List<int> message,
+}) => YttriumDart.instance.api.crateSolanaSignMessage(
+  keypairBase58: keypairBase58,
+  message: message,
+);
 
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Address>>
 abstract class Address implements RustOpaqueInterface {}
@@ -23,36 +55,43 @@ abstract class ChainAbstractionClient implements RustOpaqueInterface {
 
   set projectId(String projectId);
 
-  Future<String> erc20TokenBalance(
-      {required String chainId,
-      required Address token,
-      required Address owner});
+  Future<String> erc20TokenBalance({
+    required String chainId,
+    required Address token,
+    required Address owner,
+  });
 
   Future<Eip1559Estimation> estimateFees({required String chainId});
 
-  Future<UiFields> getUiFields(
-      {required PrepareResponseAvailable routeResponse,
-      required Currency currency});
+  Future<UiFields> getUiFields({
+    required PrepareResponseAvailable routeResponse,
+    required Currency currency,
+  });
 
   // HINT: Make it `#[frb(sync)]` to let it become the default constructor of Dart class.
-  static Future<ChainAbstractionClient> newInstance(
-          {required String projectId, required PulseMetadata pulseMetadata}) =>
-      YttriumDart.instance.api.crateChainAbstractionClientNew(
-          projectId: projectId, pulseMetadata: pulseMetadata);
+  static Future<ChainAbstractionClient> newInstance({
+    required String projectId,
+    required PulseMetadata pulseMetadata,
+  }) => YttriumDart.instance.api.crateChainAbstractionClientNew(
+    projectId: projectId,
+    pulseMetadata: pulseMetadata,
+  );
 
-  Future<PrepareResponse> prepare(
-      {required String chainId,
-      required Address from,
-      required Call call,
-      required List<String> accounts,
-      required bool useLifi});
+  Future<PrepareResponse> prepare({
+    required String chainId,
+    required Address from,
+    required Call call,
+    required List<String> accounts,
+    required bool useLifi,
+  });
 
   Future<StatusResponse> status({required String orchestrationId});
 
-  Future<StatusResponseCompleted> waitForSuccessWithTimeout(
-      {required String orchestrationId,
-      required BigInt checkIn,
-      required BigInt timeout});
+  Future<StatusResponseCompleted> waitForSuccessWithTimeout({
+    required String orchestrationId,
+    required BigInt checkIn,
+    required BigInt timeout,
+  });
 }
 
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Currency>>
@@ -104,7 +143,41 @@ class Eip1559Estimation {
 sealed class Error with _$Error implements FrbException {
   const Error._();
 
-  const factory Error.general(
-    String field0,
-  ) = Error_General;
+  const factory Error.general(String field0) = Error_General;
+}
+
+@freezed
+sealed class SolanaSignError with _$SolanaSignError implements FrbException {
+  const SolanaSignError._();
+
+  const factory SolanaSignError.invalidKeypair(String field0) =
+      SolanaSignError_InvalidKeypair;
+  const factory SolanaSignError.invalidTransaction(String field0) =
+      SolanaSignError_InvalidTransaction;
+  const factory SolanaSignError.signerNotRequired({required String pubkey}) =
+      SolanaSignError_SignerNotRequired;
+}
+
+class SolanaSignedTransactionDart {
+  /// Base58-encoded Ed25519 signature added to the transaction.
+  final String signature;
+
+  /// Base64-encoded bincode-serialized signed VersionedTransaction.
+  final String transaction;
+
+  const SolanaSignedTransactionDart({
+    required this.signature,
+    required this.transaction,
+  });
+
+  @override
+  int get hashCode => signature.hashCode ^ transaction.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SolanaSignedTransactionDart &&
+          runtimeType == other.runtimeType &&
+          signature == other.signature &&
+          transaction == other.transaction;
 }

--- a/crates/yttrium_dart/lib/generated/lib.freezed.dart
+++ b/crates/yttrium_dart/lib/generated/lib.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,105 +9,51 @@ part of 'lib.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$Error {
-  String get field0 => throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function(String field0) general,
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(String field0)? general,
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function(String field0)? general,
-    required TResult orElse(),
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(Error_General value) general,
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(Error_General value)? general,
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(Error_General value)? general,
-    required TResult orElse(),
-  }) =>
-      throw _privateConstructorUsedError;
+  String get field0;
 
   /// Create a copy of Error
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $ErrorCopyWith<Error> get copyWith => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $ErrorCopyWith<$Res> {
-  factory $ErrorCopyWith(Error value, $Res Function(Error) then) =
-      _$ErrorCopyWithImpl<$Res, Error>;
-  @useResult
-  $Res call({String field0});
-}
-
-/// @nodoc
-class _$ErrorCopyWithImpl<$Res, $Val extends Error>
-    implements $ErrorCopyWith<$Res> {
-  _$ErrorCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of Error
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
+  $ErrorCopyWith<Error> get copyWith =>
+      _$ErrorCopyWithImpl<Error>(this as Error, _$identity);
+
   @override
-  $Res call({
-    Object? field0 = null,
-  }) {
-    return _then(_value.copyWith(
-      field0: null == field0
-          ? _value.field0
-          : field0 // ignore: cast_nullable_to_non_nullable
-              as String,
-    ) as $Val);
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Error &&
+            (identical(other.field0, field0) || other.field0 == field0));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, field0);
+
+  @override
+  String toString() {
+    return 'Error(field0: $field0)';
   }
 }
 
 /// @nodoc
-abstract class _$$Error_GeneralImplCopyWith<$Res>
-    implements $ErrorCopyWith<$Res> {
-  factory _$$Error_GeneralImplCopyWith(
-          _$Error_GeneralImpl value, $Res Function(_$Error_GeneralImpl) then) =
-      __$$Error_GeneralImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $ErrorCopyWith<$Res> {
+  factory $ErrorCopyWith(Error value, $Res Function(Error) _then) =
+      _$ErrorCopyWithImpl;
   @useResult
   $Res call({String field0});
 }
 
 /// @nodoc
-class __$$Error_GeneralImplCopyWithImpl<$Res>
-    extends _$ErrorCopyWithImpl<$Res, _$Error_GeneralImpl>
-    implements _$$Error_GeneralImplCopyWith<$Res> {
-  __$$Error_GeneralImplCopyWithImpl(
-      _$Error_GeneralImpl _value, $Res Function(_$Error_GeneralImpl) _then)
-      : super(_value, _then);
+class _$ErrorCopyWithImpl<$Res> implements $ErrorCopyWith<$Res> {
+  _$ErrorCopyWithImpl(this._self, this._then);
+
+  final Error _self;
+  final $Res Function(Error) _then;
 
   /// Create a copy of Error
   /// with the given fields replaced by the non-null parameter values.
@@ -116,9 +62,515 @@ class __$$Error_GeneralImplCopyWithImpl<$Res>
   $Res call({
     Object? field0 = null,
   }) {
-    return _then(_$Error_GeneralImpl(
+    return _then(_self.copyWith(
+      field0: null == field0
+          ? _self.field0
+          : field0 // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Error].
+extension ErrorPatterns on Error {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Error_General value)? general,
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case Error_General() when general != null:
+        return general(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Error_General value) general,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case Error_General():
+        return general(_that);
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(Error_General value)? general,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case Error_General() when general != null:
+        return general(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String field0)? general,
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case Error_General() when general != null:
+        return general(_that.field0);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String field0) general,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case Error_General():
+        return general(_that.field0);
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String field0)? general,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case Error_General() when general != null:
+        return general(_that.field0);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class Error_General extends Error {
+  const Error_General(this.field0) : super._();
+
+  @override
+  final String field0;
+
+  /// Create a copy of Error
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $Error_GeneralCopyWith<Error_General> get copyWith =>
+      _$Error_GeneralCopyWithImpl<Error_General>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Error_General &&
+            (identical(other.field0, field0) || other.field0 == field0));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, field0);
+
+  @override
+  String toString() {
+    return 'Error.general(field0: $field0)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $Error_GeneralCopyWith<$Res>
+    implements $ErrorCopyWith<$Res> {
+  factory $Error_GeneralCopyWith(
+          Error_General value, $Res Function(Error_General) _then) =
+      _$Error_GeneralCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String field0});
+}
+
+/// @nodoc
+class _$Error_GeneralCopyWithImpl<$Res>
+    implements $Error_GeneralCopyWith<$Res> {
+  _$Error_GeneralCopyWithImpl(this._self, this._then);
+
+  final Error_General _self;
+  final $Res Function(Error_General) _then;
+
+  /// Create a copy of Error
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? field0 = null,
+  }) {
+    return _then(Error_General(
       null == field0
-          ? _value.field0
+          ? _self.field0
+          : field0 // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+mixin _$SolanaSignError {
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is SolanaSignError);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() {
+    return 'SolanaSignError()';
+  }
+}
+
+/// @nodoc
+class $SolanaSignErrorCopyWith<$Res> {
+  $SolanaSignErrorCopyWith(
+      SolanaSignError _, $Res Function(SolanaSignError) __);
+}
+
+/// Adds pattern-matching-related methods to [SolanaSignError].
+extension SolanaSignErrorPatterns on SolanaSignError {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(SolanaSignError_InvalidKeypair value)? invalidKeypair,
+    TResult Function(SolanaSignError_InvalidTransaction value)?
+        invalidTransaction,
+    TResult Function(SolanaSignError_SignerNotRequired value)?
+        signerNotRequired,
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case SolanaSignError_InvalidKeypair() when invalidKeypair != null:
+        return invalidKeypair(_that);
+      case SolanaSignError_InvalidTransaction() when invalidTransaction != null:
+        return invalidTransaction(_that);
+      case SolanaSignError_SignerNotRequired() when signerNotRequired != null:
+        return signerNotRequired(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(SolanaSignError_InvalidKeypair value)
+        invalidKeypair,
+    required TResult Function(SolanaSignError_InvalidTransaction value)
+        invalidTransaction,
+    required TResult Function(SolanaSignError_SignerNotRequired value)
+        signerNotRequired,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case SolanaSignError_InvalidKeypair():
+        return invalidKeypair(_that);
+      case SolanaSignError_InvalidTransaction():
+        return invalidTransaction(_that);
+      case SolanaSignError_SignerNotRequired():
+        return signerNotRequired(_that);
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(SolanaSignError_InvalidKeypair value)? invalidKeypair,
+    TResult? Function(SolanaSignError_InvalidTransaction value)?
+        invalidTransaction,
+    TResult? Function(SolanaSignError_SignerNotRequired value)?
+        signerNotRequired,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case SolanaSignError_InvalidKeypair() when invalidKeypair != null:
+        return invalidKeypair(_that);
+      case SolanaSignError_InvalidTransaction() when invalidTransaction != null:
+        return invalidTransaction(_that);
+      case SolanaSignError_SignerNotRequired() when signerNotRequired != null:
+        return signerNotRequired(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String field0)? invalidKeypair,
+    TResult Function(String field0)? invalidTransaction,
+    TResult Function(String pubkey)? signerNotRequired,
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case SolanaSignError_InvalidKeypair() when invalidKeypair != null:
+        return invalidKeypair(_that.field0);
+      case SolanaSignError_InvalidTransaction() when invalidTransaction != null:
+        return invalidTransaction(_that.field0);
+      case SolanaSignError_SignerNotRequired() when signerNotRequired != null:
+        return signerNotRequired(_that.pubkey);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String field0) invalidKeypair,
+    required TResult Function(String field0) invalidTransaction,
+    required TResult Function(String pubkey) signerNotRequired,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case SolanaSignError_InvalidKeypair():
+        return invalidKeypair(_that.field0);
+      case SolanaSignError_InvalidTransaction():
+        return invalidTransaction(_that.field0);
+      case SolanaSignError_SignerNotRequired():
+        return signerNotRequired(_that.pubkey);
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String field0)? invalidKeypair,
+    TResult? Function(String field0)? invalidTransaction,
+    TResult? Function(String pubkey)? signerNotRequired,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case SolanaSignError_InvalidKeypair() when invalidKeypair != null:
+        return invalidKeypair(_that.field0);
+      case SolanaSignError_InvalidTransaction() when invalidTransaction != null:
+        return invalidTransaction(_that.field0);
+      case SolanaSignError_SignerNotRequired() when signerNotRequired != null:
+        return signerNotRequired(_that.pubkey);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class SolanaSignError_InvalidKeypair extends SolanaSignError {
+  const SolanaSignError_InvalidKeypair(this.field0) : super._();
+
+  final String field0;
+
+  /// Create a copy of SolanaSignError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $SolanaSignError_InvalidKeypairCopyWith<SolanaSignError_InvalidKeypair>
+      get copyWith => _$SolanaSignError_InvalidKeypairCopyWithImpl<
+          SolanaSignError_InvalidKeypair>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is SolanaSignError_InvalidKeypair &&
+            (identical(other.field0, field0) || other.field0 == field0));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, field0);
+
+  @override
+  String toString() {
+    return 'SolanaSignError.invalidKeypair(field0: $field0)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $SolanaSignError_InvalidKeypairCopyWith<$Res>
+    implements $SolanaSignErrorCopyWith<$Res> {
+  factory $SolanaSignError_InvalidKeypairCopyWith(
+          SolanaSignError_InvalidKeypair value,
+          $Res Function(SolanaSignError_InvalidKeypair) _then) =
+      _$SolanaSignError_InvalidKeypairCopyWithImpl;
+  @useResult
+  $Res call({String field0});
+}
+
+/// @nodoc
+class _$SolanaSignError_InvalidKeypairCopyWithImpl<$Res>
+    implements $SolanaSignError_InvalidKeypairCopyWith<$Res> {
+  _$SolanaSignError_InvalidKeypairCopyWithImpl(this._self, this._then);
+
+  final SolanaSignError_InvalidKeypair _self;
+  final $Res Function(SolanaSignError_InvalidKeypair) _then;
+
+  /// Create a copy of SolanaSignError
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? field0 = null,
+  }) {
+    return _then(SolanaSignError_InvalidKeypair(
+      null == field0
+          ? _self.field0
           : field0 // ignore: cast_nullable_to_non_nullable
               as String,
     ));
@@ -127,104 +579,135 @@ class __$$Error_GeneralImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$Error_GeneralImpl extends Error_General {
-  const _$Error_GeneralImpl(this.field0) : super._();
+class SolanaSignError_InvalidTransaction extends SolanaSignError {
+  const SolanaSignError_InvalidTransaction(this.field0) : super._();
 
-  @override
   final String field0;
 
-  @override
-  String toString() {
-    return 'Error.general(field0: $field0)';
-  }
+  /// Create a copy of SolanaSignError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $SolanaSignError_InvalidTransactionCopyWith<
+          SolanaSignError_InvalidTransaction>
+      get copyWith => _$SolanaSignError_InvalidTransactionCopyWithImpl<
+          SolanaSignError_InvalidTransaction>(this, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$Error_GeneralImpl &&
+            other is SolanaSignError_InvalidTransaction &&
             (identical(other.field0, field0) || other.field0 == field0));
   }
 
   @override
   int get hashCode => Object.hash(runtimeType, field0);
 
-  /// Create a copy of Error
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
+  String toString() {
+    return 'SolanaSignError.invalidTransaction(field0: $field0)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $SolanaSignError_InvalidTransactionCopyWith<$Res>
+    implements $SolanaSignErrorCopyWith<$Res> {
+  factory $SolanaSignError_InvalidTransactionCopyWith(
+          SolanaSignError_InvalidTransaction value,
+          $Res Function(SolanaSignError_InvalidTransaction) _then) =
+      _$SolanaSignError_InvalidTransactionCopyWithImpl;
+  @useResult
+  $Res call({String field0});
+}
+
+/// @nodoc
+class _$SolanaSignError_InvalidTransactionCopyWithImpl<$Res>
+    implements $SolanaSignError_InvalidTransactionCopyWith<$Res> {
+  _$SolanaSignError_InvalidTransactionCopyWithImpl(this._self, this._then);
+
+  final SolanaSignError_InvalidTransaction _self;
+  final $Res Function(SolanaSignError_InvalidTransaction) _then;
+
+  /// Create a copy of SolanaSignError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
-  _$$Error_GeneralImplCopyWith<_$Error_GeneralImpl> get copyWith =>
-      __$$Error_GeneralImplCopyWithImpl<_$Error_GeneralImpl>(this, _$identity);
-
-  @override
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function(String field0) general,
+  $Res call({
+    Object? field0 = null,
   }) {
-    return general(field0);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(String field0)? general,
-  }) {
-    return general?.call(field0);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function(String field0)? general,
-    required TResult orElse(),
-  }) {
-    if (general != null) {
-      return general(field0);
-    }
-    return orElse();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(Error_General value) general,
-  }) {
-    return general(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(Error_General value)? general,
-  }) {
-    return general?.call(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(Error_General value)? general,
-    required TResult orElse(),
-  }) {
-    if (general != null) {
-      return general(this);
-    }
-    return orElse();
+    return _then(SolanaSignError_InvalidTransaction(
+      null == field0
+          ? _self.field0
+          : field0 // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
   }
 }
 
-abstract class Error_General extends Error {
-  const factory Error_General(final String field0) = _$Error_GeneralImpl;
-  const Error_General._() : super._();
+/// @nodoc
 
-  @override
-  String get field0;
+class SolanaSignError_SignerNotRequired extends SolanaSignError {
+  const SolanaSignError_SignerNotRequired({required this.pubkey}) : super._();
 
-  /// Create a copy of Error
+  final String pubkey;
+
+  /// Create a copy of SolanaSignError
   /// with the given fields replaced by the non-null parameter values.
-  @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$Error_GeneralImplCopyWith<_$Error_GeneralImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  $SolanaSignError_SignerNotRequiredCopyWith<SolanaSignError_SignerNotRequired>
+      get copyWith => _$SolanaSignError_SignerNotRequiredCopyWithImpl<
+          SolanaSignError_SignerNotRequired>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is SolanaSignError_SignerNotRequired &&
+            (identical(other.pubkey, pubkey) || other.pubkey == pubkey));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, pubkey);
+
+  @override
+  String toString() {
+    return 'SolanaSignError.signerNotRequired(pubkey: $pubkey)';
+  }
 }
+
+/// @nodoc
+abstract mixin class $SolanaSignError_SignerNotRequiredCopyWith<$Res>
+    implements $SolanaSignErrorCopyWith<$Res> {
+  factory $SolanaSignError_SignerNotRequiredCopyWith(
+          SolanaSignError_SignerNotRequired value,
+          $Res Function(SolanaSignError_SignerNotRequired) _then) =
+      _$SolanaSignError_SignerNotRequiredCopyWithImpl;
+  @useResult
+  $Res call({String pubkey});
+}
+
+/// @nodoc
+class _$SolanaSignError_SignerNotRequiredCopyWithImpl<$Res>
+    implements $SolanaSignError_SignerNotRequiredCopyWith<$Res> {
+  _$SolanaSignError_SignerNotRequiredCopyWithImpl(this._self, this._then);
+
+  final SolanaSignError_SignerNotRequired _self;
+  final $Res Function(SolanaSignError_SignerNotRequired) _then;
+
+  /// Create a copy of SolanaSignError
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? pubkey = null,
+  }) {
+    return _then(SolanaSignError_SignerNotRequired(
+      pubkey: null == pubkey
+          ? _self.pubkey
+          : pubkey // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+// dart format on

--- a/crates/yttrium_dart/lib/yttrium_dart.dart
+++ b/crates/yttrium_dart/lib/yttrium_dart.dart
@@ -3,6 +3,13 @@ import 'dart:io';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:yttrium_dart/generated/frb_generated.dart' as frb;
 import 'package:yttrium_dart/generated/lib.dart';
+export 'package:yttrium_dart/generated/lib.dart'
+    show
+        SolanaSignError,
+        SolanaSignedTransactionDart,
+        solanaSignAllTransactions,
+        solanaSignMessage,
+        solanaSignTransaction;
 
 class YttriumDart implements ChainAbstractionClient {
   // Singleton instance

--- a/crates/yttrium_dart/rust/Cargo.toml
+++ b/crates/yttrium_dart/rust/Cargo.toml
@@ -15,7 +15,7 @@ flutter_rust_bridge_codegen = "2.6.0"
 
 [dependencies]
 flutter_rust_bridge = "=2.10.0"
-yttrium = { path = "../../yttrium" }
+yttrium = { path = "../../yttrium", features = ["solana"] }
 # uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "e796e00ad150f8b14b61a859a2e8c6497b35074e" }
 openssl = { version = "0.10", features = ["vendored"] }
 openssl-sys = { version = "0.9.103", features = ["vendored"] }
@@ -27,6 +27,11 @@ thiserror.workspace = true
 
 alloy.workspace = true
 erc6492.workspace = true
+
+# Solana
+solana-signer.workspace = true
+bs58.workspace = true
+data-encoding.workspace = true
 
 # Async
 tokio.workspace = true

--- a/crates/yttrium_dart/rust/src/frb_generated.rs
+++ b/crates/yttrium_dart/rust/src/frb_generated.rs
@@ -42,7 +42,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.10.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1433861761;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -648847146;
 
 // Section: executor
 
@@ -268,6 +268,54 @@ let decode_indices_ = flutter_rust_bridge::for_generated::lockable_compute_decod
         let api_that_guard = api_that_guard.unwrap();
  let output_ok = crate::ChainAbstractionClient::wait_for_success_with_timeout(&*api_that_guard, api_orchestration_id, api_check_in, api_timeout).await?;   Ok(output_ok)
                     })().await)
+                } })
+}
+fn wire__crate__solana_sign_all_transactions_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec,_,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "solana_sign_all_transactions", port: Some(port_), mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal }, move || {
+            let message = unsafe { flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(ptr_, rust_vec_len_, data_len_) };
+            let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_keypair_base58 = <String>::sse_decode(&mut deserializer);
+let api_transactions_base64 = <Vec<String>>::sse_decode(&mut deserializer);deserializer.end(); move |context|  {
+                    transform_result_sse::<_, crate::SolanaSignError>((move ||  {
+                         let output_ok = crate::solana_sign_all_transactions(api_keypair_base58, api_transactions_base64)?;   Ok(output_ok)
+                    })())
+                } })
+}
+fn wire__crate__solana_sign_message_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec,_,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "solana_sign_message", port: Some(port_), mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal }, move || {
+            let message = unsafe { flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(ptr_, rust_vec_len_, data_len_) };
+            let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_keypair_base58 = <String>::sse_decode(&mut deserializer);
+let api_message = <Vec<u8>>::sse_decode(&mut deserializer);deserializer.end(); move |context|  {
+                    transform_result_sse::<_, crate::SolanaSignError>((move ||  {
+                         let output_ok = crate::solana_sign_message(api_keypair_base58, api_message)?;   Ok(output_ok)
+                    })())
+                } })
+}
+fn wire__crate__solana_sign_transaction_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec,_,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "solana_sign_transaction", port: Some(port_), mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal }, move || {
+            let message = unsafe { flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(ptr_, rust_vec_len_, data_len_) };
+            let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_keypair_base58 = <String>::sse_decode(&mut deserializer);
+let api_transaction_base64 = <String>::sse_decode(&mut deserializer);deserializer.end(); move |context|  {
+                    transform_result_sse::<_, crate::SolanaSignError>((move ||  {
+                         let output_ok = crate::solana_sign_transaction(api_keypair_base58, api_transaction_base64)?;   Ok(output_ok)
+                    })())
                 } })
 }
 
@@ -671,6 +719,64 @@ impl SseDecode for Vec<u8> {
     }
 }
 
+impl SseDecode for Vec<crate::SolanaSignedTransactionDart> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(
+        deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer,
+    ) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<crate::SolanaSignedTransactionDart>::sse_decode(
+                deserializer,
+            ));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for crate::SolanaSignError {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(
+        deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer,
+    ) -> Self {
+        let mut tag_ = <i32>::sse_decode(deserializer);
+        match tag_ {
+            0 => {
+                let mut var_field0 = <String>::sse_decode(deserializer);
+                return crate::SolanaSignError::InvalidKeypair(var_field0);
+            }
+            1 => {
+                let mut var_field0 = <String>::sse_decode(deserializer);
+                return crate::SolanaSignError::InvalidTransaction(var_field0);
+            }
+            2 => {
+                let mut var_pubkey = <String>::sse_decode(deserializer);
+                return crate::SolanaSignError::SignerNotRequired {
+                    pubkey: var_pubkey,
+                };
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+
+impl SseDecode for crate::SolanaSignedTransactionDart {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(
+        deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer,
+    ) -> Self {
+        let mut var_signature = <String>::sse_decode(deserializer);
+        let mut var_transaction = <String>::sse_decode(deserializer);
+        return crate::SolanaSignedTransactionDart {
+            signature: var_signature,
+            transaction: var_transaction,
+        };
+    }
+}
+
 impl SseDecode for u64 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(
@@ -731,6 +837,9 @@ fn pde_ffi_dispatcher_primary_impl(
 7 => wire__crate__ChainAbstractionClient_prepare_impl(port, ptr, rust_vec_len, data_len),
 8 => wire__crate__ChainAbstractionClient_status_impl(port, ptr, rust_vec_len, data_len),
 9 => wire__crate__ChainAbstractionClient_wait_for_success_with_timeout_impl(port, ptr, rust_vec_len, data_len),
+10 => wire__crate__solana_sign_all_transactions_impl(port, ptr, rust_vec_len, data_len),
+11 => wire__crate__solana_sign_message_impl(port, ptr, rust_vec_len, data_len),
+12 => wire__crate__solana_sign_transaction_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -1013,6 +1122,57 @@ impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
 }
 impl flutter_rust_bridge::IntoIntoDart<crate::Error> for crate::Error {
     fn into_into_dart(self) -> crate::Error {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::SolanaSignError {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self {
+            crate::SolanaSignError::InvalidKeypair(field0) => {
+                [0.into_dart(), field0.into_into_dart().into_dart()].into_dart()
+            }
+            crate::SolanaSignError::InvalidTransaction(field0) => {
+                [1.into_dart(), field0.into_into_dart().into_dart()].into_dart()
+            }
+            crate::SolanaSignError::SignerNotRequired { pubkey } => {
+                [2.into_dart(), pubkey.into_into_dart().into_dart()].into_dart()
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::SolanaSignError
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::SolanaSignError>
+    for crate::SolanaSignError
+{
+    fn into_into_dart(self) -> crate::SolanaSignError {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::SolanaSignedTransactionDart {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.signature.into_into_dart().into_dart(),
+            self.transaction.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::SolanaSignedTransactionDart
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::SolanaSignedTransactionDart>
+    for crate::SolanaSignedTransactionDart
+{
+    fn into_into_dart(self) -> crate::SolanaSignedTransactionDart {
         self
     }
 }
@@ -1449,6 +1609,56 @@ impl SseEncode for Vec<u8> {
         for item in self {
             <u8>::sse_encode(item, serializer);
         }
+    }
+}
+
+impl SseEncode for Vec<crate::SolanaSignedTransactionDart> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(
+        self,
+        serializer: &mut flutter_rust_bridge::for_generated::SseSerializer,
+    ) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <crate::SolanaSignedTransactionDart>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for crate::SolanaSignError {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(
+        self,
+        serializer: &mut flutter_rust_bridge::for_generated::SseSerializer,
+    ) {
+        match self {
+            crate::SolanaSignError::InvalidKeypair(field0) => {
+                <i32>::sse_encode(0, serializer);
+                <String>::sse_encode(field0, serializer);
+            }
+            crate::SolanaSignError::InvalidTransaction(field0) => {
+                <i32>::sse_encode(1, serializer);
+                <String>::sse_encode(field0, serializer);
+            }
+            crate::SolanaSignError::SignerNotRequired { pubkey } => {
+                <i32>::sse_encode(2, serializer);
+                <String>::sse_encode(pubkey, serializer);
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+
+impl SseEncode for crate::SolanaSignedTransactionDart {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(
+        self,
+        serializer: &mut flutter_rust_bridge::for_generated::SseSerializer,
+    ) {
+        <String>::sse_encode(self.signature, serializer);
+        <String>::sse_encode(self.transaction, serializer);
     }
 }
 

--- a/crates/yttrium_dart/rust/src/lib.rs
+++ b/crates/yttrium_dart/rust/src/lib.rs
@@ -5,6 +5,7 @@ use {
         providers::{Provider, ProviderBuilder},
     },
     relay_rpc::domain::ProjectId,
+    solana_signer::Signer,
     std::time::Duration,
     yttrium::{
         call::Call,
@@ -15,9 +16,13 @@ use {
             },
             client::Client,
             currency::Currency,
-            pulse::PulseMetadata,
+            solana::{
+                self, SolanaKeypair, SolanaSignTransactionError,
+                SolanaVersionedTransaction, sign_versioned_transaction,
+            },
             ui_fields::UiFields,
         },
+        pulse::PulseMetadata,
     },
 };
 
@@ -191,7 +196,7 @@ impl ChainAbstractionClient {
         .expect("Invalid RPC URL");
         let provider = ProviderBuilder::new().connect_http(url);
         provider
-            .estimate_eip1559_fees(None)
+            .estimate_eip1559_fees()
             .await
             .map(Into::into)
             .map_err(|e| Error::General(e.to_string()))
@@ -210,6 +215,107 @@ impl ChainAbstractionClient {
             .map(|balance| balance.to_string())
             .map_err(|e| Error::General(e.to_string()))
     }
+}
+
+#[derive(Clone, Debug)]
+pub struct SolanaSignedTransactionDart {
+    /// Base58-encoded Ed25519 signature added to the transaction.
+    pub signature: String,
+    /// Base64-encoded bincode-serialized signed VersionedTransaction.
+    pub transaction: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SolanaSignError {
+    #[error("invalid keypair: {0}")]
+    InvalidKeypair(String),
+    #[error("invalid transaction: {0}")]
+    InvalidTransaction(String),
+    #[error(
+        "signer pubkey {pubkey} is not a required signer of this transaction"
+    )]
+    SignerNotRequired { pubkey: String },
+}
+
+impl From<SolanaSignTransactionError> for SolanaSignError {
+    fn from(e: SolanaSignTransactionError) -> Self {
+        match e {
+            SolanaSignTransactionError::SignerNotRequired { pubkey } => {
+                Self::SignerNotRequired { pubkey }
+            }
+        }
+    }
+}
+
+fn parse_solana_keypair(
+    base58: &str,
+) -> Result<SolanaKeypair, SolanaSignError> {
+    let mut buf = [0u8; relay_rpc::auth::ed25519_dalek::KEYPAIR_LENGTH];
+    bs58::decode(base58)
+        .onto(&mut buf)
+        .map_err(|e| SolanaSignError::InvalidKeypair(e.to_string()))?;
+    SolanaKeypair::try_from(buf.as_ref())
+        .map_err(|e| SolanaSignError::InvalidKeypair(e.to_string()))
+}
+
+fn parse_solana_transaction(
+    base64: &str,
+) -> Result<SolanaVersionedTransaction, SolanaSignError> {
+    let bytes = data_encoding::BASE64
+        .decode(base64.as_bytes())
+        .map_err(|e| SolanaSignError::InvalidTransaction(e.to_string()))?;
+    solana::bincode::deserialize::<SolanaVersionedTransaction>(&bytes)
+        .map_err(|e| SolanaSignError::InvalidTransaction(e.to_string()))
+}
+
+fn encode_signed_transaction(
+    signed: solana::SolanaSignedTransaction,
+) -> SolanaSignedTransactionDart {
+    SolanaSignedTransactionDart {
+        signature: signed.signature.to_string(),
+        transaction: data_encoding::BASE64
+            .encode(&solana::bincode::serialize(&signed.transaction).unwrap()),
+    }
+}
+
+/// Signs a Solana `VersionedTransaction` using the WalletConnect
+/// `solana_signTransaction` wire format (base64-bincode transaction,
+/// base58 keypair). Returns the signed transaction re-encoded as base64
+/// plus the base58 signature placed at the keypair's signer slot.
+pub fn solana_sign_transaction(
+    keypair_base58: String,
+    transaction_base64: String,
+) -> Result<SolanaSignedTransactionDart, SolanaSignError> {
+    let keypair = parse_solana_keypair(&keypair_base58)?;
+    let transaction = parse_solana_transaction(&transaction_base64)?;
+    let signed = sign_versioned_transaction(&keypair, transaction)?;
+    Ok(encode_signed_transaction(signed))
+}
+
+/// Batched variant matching WalletConnect's `solana_signAllTransactions`.
+pub fn solana_sign_all_transactions(
+    keypair_base58: String,
+    transactions_base64: Vec<String>,
+) -> Result<Vec<SolanaSignedTransactionDart>, SolanaSignError> {
+    let keypair = parse_solana_keypair(&keypair_base58)?;
+    transactions_base64
+        .iter()
+        .map(|s| {
+            let tx = parse_solana_transaction(s)?;
+            let signed = sign_versioned_transaction(&keypair, tx)?;
+            Ok(encode_signed_transaction(signed))
+        })
+        .collect()
+}
+
+/// Signs arbitrary bytes (WalletConnect's `solana_signMessage`). Returns
+/// the base58-encoded Ed25519 signature.
+pub fn solana_sign_message(
+    keypair_base58: String,
+    message: Vec<u8>,
+) -> Result<String, SolanaSignError> {
+    let keypair = parse_solana_keypair(&keypair_base58)?;
+    Ok(keypair.sign_message(&message).to_string())
 }
 
 #[cfg(test)]
@@ -232,10 +338,11 @@ mod tests {
             "https://rpc.walletconnect.com/v1?chainId={chain_id}&projectId={project_id}")
         .parse()
         .expect("Invalid RPC URL");
-        let provider =
-            ProviderBuilder::new().disable_recommended_fillers().connect_http(url);
+        let provider = ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .connect_http(url);
 
-        let estimate = provider.estimate_eip1559_fees(None).await.unwrap();
+        let estimate = provider.estimate_eip1559_fees().await.unwrap();
 
         println!("estimate: {estimate:?}");
         // Simulate sending the data to Dart (convert U128 values to strings)
@@ -243,7 +350,9 @@ mod tests {
         let max_priority_fee_per_gas =
             estimate.max_priority_fee_per_gas.to_string();
 
-        println!("Max fee per gas: {max_fee_per_gas}, Max priority fee per gas: {max_priority_fee_per_gas}");
+        println!(
+            "Max fee per gas: {max_fee_per_gas}, Max priority fee per gas: {max_priority_fee_per_gas}"
+        );
     }
 
     #[test]

--- a/scripts/build-utils-xcframework.sh
+++ b/scripts/build-utils-xcframework.sh
@@ -5,7 +5,7 @@ set -u
 
 PACKAGE_NAME="yttrium"
 # Use chain_abstraction_client which will include Sui code without explicit sui feature
-FEATURES="ios,eip155,chain_abstraction_client,stacks,sui,ton,tron,clear_signing,evm_signing"
+FEATURES="ios,eip155,chain_abstraction_client,solana,stacks,sui,ton,tron,clear_signing,evm_signing"
 PROFILE="xcframework-release"
 fat_simulator_lib_dir="target/ios-simulator-fat/$PROFILE-utils"
 swift_package_dir="platforms/swift/Sources/YttriumUtils"


### PR DESCRIPTION
## Summary

Adds three free FFI functions and supporting types to `uniffi_compat/mod.rs` so Swift/Kotlin/Flutter wallets can handle WalletConnect's `solana_signTransaction`, `solana_signAllTransactions`, and `solana_signMessage` JSON-RPC methods without reimplementing bincode/base64 unpacking, signer-slot lookup, and signature placement.

- `solana_sign_transaction(keypair, VersionedTransaction) -> Result<SolanaSignedTransaction, SolanaSignTransactionError>` — locates the keypair's pubkey in the first `num_required_signatures` static account keys (ALT-loaded keys cannot be signers), signs `message.serialize()`, pads the signatures vec if the dapp sent it short, and writes the signature at the correct index.
- `solana_sign_all_transactions` — same primitive applied across a `Vec`, order preserved.
- `solana_sign_message(keypair, Bytes) -> SolanaSignature` — thin alias for `solana_sign_prehash` to match the WC method name.

Reuses the existing `VersionedTransaction` (base64+bincode) and `SolanaSignature` (base58) UniFFI custom_type wiring, so consumers can pass JSON-RPC wire values straight through.

## Test plan

- [x] `cargo build -p yttrium --features=full`
- [x] `cargo test -p yttrium --features=full --lib uniffi_compat::tests::solana_sign` — 5 new unit tests pass (sign+verify, signer-not-required rejection, sign_all order preservation, sign_message == sign_prehash, signatures-vec padding)
- [x] `cargo +nightly fmt --all`
- [x] `cargo clippy -p yttrium --features=full --lib --tests --bins -- -D warnings`
- [ ] Smoke-test bindings downstream via `just kotlin` / `just swift`
- [x] Test feature in Swift Wallet
- [x] Test feature in Kotlin Wallet
- [x] Test feature in Flutter Wallet

🤖 Generated with [Claude Code](https://claude.com/claude-code)