### PR TITLE
chore(audit): ignore RUSTSEC-2026-0107 (mysten-metrics name-squat false positive)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -12,7 +12,10 @@ ignore = [
     "RUSTSEC-2024-0437",
     # rsa: timing sidechannel, transitive via sui-sdk (git pin) -> fastcrypto
     "RUSTSEC-2023-0071",
-    # rustls-webpki 0.101.7: name constraints + CRL parsing panic, transitive via sui-sdk (git pin) -> sct/rustls 0.21
+    # rustls-webpki 0.101.7 (name constraints + CRL parse panics). Inactive:
+    # a pinned-but-uncompiled optional transitive of aws-smithy-http-client's
+    # legacy-rustls-ring feature, which nothing in our manifests enables. Real
+    # builds resolve to rustls 0.23 -> the patched rustls-webpki 0.103.13.
     "RUSTSEC-2026-0098",
     "RUSTSEC-2026-0099",
     "RUSTSEC-2026-0104",

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -16,4 +16,7 @@ ignore = [
     "RUSTSEC-2026-0098",
     "RUSTSEC-2026-0099",
     "RUSTSEC-2026-0104",
+    # mysten-metrics: malicious crates.io name-squat (removed). False positive --
+    # ours is the official Sui git pin (mystenlabs/sui@f9c8d50), not crates.io.
+    "RUSTSEC-2026-0107",
 ]


### PR DESCRIPTION
## What

Adds `RUSTSEC-2026-0107` to `.cargo/audit.toml`'s ignore list so the Security Audit CI check (`rustsec/audit-check`) stays green.

## Why — Dependabot alert #53 is a false positive

[Alert #53](https://github.com/reown-com/yttrium/security/dependabot/53) / [GHSA-g38r-8gmr-ghrf](https://github.com/advisories/GHSA-g38r-8gmr-ghrf) flags `mysten-metrics` as critical: a crate of that name was published to crates.io on 2026-04-20 with a malicious build script, then removed.

That package **never existed in our dependency tree**:

- `mysten-metrics` does not exist on crates.io (it was a name-squat — one version, no usage, since deleted).
- Our `mysten-metrics` 0.7.0 comes solely from the **official Sui git pin**, verified by commit hash:
  ```
  source = "git+https://github.com/mystenlabs/sui?rev=f9c8d50#f9c8d503..."
  ```
- It's a transitive dep via `sui_sdk`/`sui_types`, behind the optional `sui` feature. No code references it directly.

Dependabot matches by `ecosystem + name + range (>= 0)`, so it can't distinguish our git source from the squatted crates.io name. There is no patched version, and nothing to change in the dependency graph. `cargo audit` reads `Cargo.lock` and matches the same way (the existing ignore entries are all git-pinned Sui transitives), so it would also flag this — hence the ignore entry, following the established convention in this file.

The Dependabot alert has been dismissed as *inaccurate*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Also in this PR (commit 2):** corrected the `rustls-webpki 0.101.7` ignore comment (RUSTSEC-2026-0098/0099/0104). It previously blamed the Sui git pin; the real source is `aws-smithy-http-client`'s optional `legacy-rustls-ring` feature (rustls 0.21), which nothing in our manifests enables — so it's pinned in `Cargo.lock` but never compiled. Real builds use rustls 0.23 → patched `rustls-webpki 0.103.13`. Comment-only; ignore entries unchanged. Relates to Dependabot alert #52 (dismissed as *not used*).
