### PR TITLE
fix(deps): bump openssl 0.10.76 -> 0.10.79 (CVE-2026-42327)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8453,15 +8453,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -8500,9 +8499,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## What

Bumps `openssl` `0.10.76` → `0.10.79` (and `openssl-sys` `0.9.112` → `0.9.116`) in `Cargo.lock`. Lockfile-only — no manifest change.

## Why — resolves Dependabot alert #54

[Alert #54](https://github.com/reown-com/yttrium/security/dependabot/54) / [GHSA-xp3w-r5p5-63rr](https://github.com/rust-openssl/rust-openssl/security/advisories/GHSA-xp3w-r5p5-63rr) / CVE-2026-42327 (high): `X509Ref::ocsp_responders` returns OCSP responder URLs as `OpensslString`, whose `Deref` uses `str::from_utf8_unchecked`. OpenSSL doesn't enforce ASCII on the IA5String, so a certificate with non-UTF-8 bytes in its OCSP accessLocation lets safe Rust construct a `&str` that violates the UTF-8 invariant → undefined behavior.

- Affected range: `>= 0.9.7, < 0.10.79`; we were on `0.10.76`.
- `openssl` is a direct dep (`features = ["vendored"]`) in `crates/kotlin-ffi` and `crates/yttrium_dart/rust`, declared as `"0.10"` — which already permits `0.10.79`, so only the lockfile changes.

Merging this auto-closes the alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)