### PR TITLE
ci: disable sign-flow tests pending relay-side irn_fetchMessages fix

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,6 +1,6 @@
 name: sign-canary
 on:
-  push:
+  workflow_dispatch:
 
 concurrency: ${{ github.workflow }}
 

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,5 +1,7 @@
 name: sign-canary
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 concurrency: ${{ github.workflow }}
@@ -9,6 +11,9 @@ env:
 
 jobs:
   test:
+    # Disabled on push: blocked on relay-side irn_fetchMessages bug.
+    # Re-runnable on demand via workflow_dispatch.
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -37,8 +42,10 @@ jobs:
           WC_SIGN_RELAY_URL: wss://staging-relay.walletconnect.org
 
   push:
+    # Image publish runs on push to main without waiting on `test`, which is
+    # currently disabled (see comment above). This is the canary image, not a
+    # prod release.
     if: ${{ github.ref == 'refs/heads/main' }}
-    needs: test
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,6 +1,6 @@
 name: Playwright Tests
 on:
-  pull_request:
+  workflow_dispatch:
 permissions:
   contents: read
 jobs:

--- a/crates/yttrium/src/sign/tests/mod.rs
+++ b/crates/yttrium/src/sign/tests/mod.rs
@@ -1,6 +1,7 @@
 use crate::sign::test_helpers::test_sign_impl;
 
 #[tokio::test]
+#[ignore = "blocked on relay-side irn_fetchMessages bug"]
 async fn test_sign() {
     tracing_subscriber::fmt().with_max_level(tracing::Level::DEBUG).init();
 


### PR DESCRIPTION
## Summary

After `wc_proposeSession` returns `true`, the wallet's subsequent `irn_fetchMessages` call returns `messages: []` indefinitely on both prod and staging relays — verified locally via `cargo test` and Playwright trace inspection. A bounded retry/backoff in `Client::pair()` does not help because the message is never delivered at all.

This PR:
- **`sign-canary` workflow**: skips the `test` job (4 invocations across prod + staging) on push; image publish to ECR + GHCR still runs on push to `main` so the running canary doesn't go stale. Full run available via `workflow_dispatch`.
- **`Playwright Tests` workflow**: switched to `workflow_dispatch` only (all 6 active specs go through the broken `pair()` flow).
- **Rust `sign::tests::test_sign`**: marked `#[ignore]` with a descriptive reason.

## Test plan

- [ ] Confirm `sign-canary` `test` job is skipped on push to this branch, and `push` (image publish) only fires on `main`
- [ ] Confirm `Playwright Tests` no longer runs on PR
- [ ] `cargo test --features=full,test_depends_on_env_REOWN_PROJECT_ID --lib --bins` passes without the previously-failing `test_sign`
- [ ] After relay fix: trigger `sign-canary` via `workflow_dispatch` to re-verify, then revert the three disables

🤖 Generated with [Claude Code](https://claude.com/claude-code)