### PR TITLE
ci(swift): treat post-publish trunk verification timeout as success

### DIFF
--- a/.github/workflows/publish-swift-utils.yml
+++ b/.github/workflows/publish-swift-utils.yml
@@ -122,6 +122,37 @@ jobs:
       - name: Publish Utils CocoaPods
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+          POD_NAME: YttriumUtilsWrapper
+          POD_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          pod trunk push YttriumUtilsWrapper.podspec --allow-warnings
+          # pod trunk push is "publish, then verify the LICENSE URL via GitHub
+          # API". When that post-publish verification times out the spec has
+          # already been accepted but the command exits non-zero, and any
+          # retry fails with "duplicate entry". Detect that case and treat it
+          # as success.
+          set +e
+          pod trunk push "${POD_NAME}.podspec" --allow-warnings
+          PUSH_EXIT=$?
+          set -e
+
+          if [ $PUSH_EXIT -eq 0 ]; then
+            exit 0
+          fi
+
+          echo "::warning::pod trunk push exited ${PUSH_EXIT} — checking whether ${POD_NAME} ${POD_VERSION} landed on trunk anyway"
+          TRUNK_JSON=$(curl -sf --retry 3 --retry-delay 2 \
+            "https://trunk.cocoapods.org/api/v1/pods/${POD_NAME}") || {
+              echo "::error::pod trunk push failed (exit ${PUSH_EXIT}) and trunk API unreachable"
+              exit $PUSH_EXIT
+            }
+
+          if echo "$TRUNK_JSON" | jq -e --arg v "$POD_VERSION" \
+               '.versions | map(.name) | index($v)' >/dev/null; then
+            echo "::notice::${POD_NAME} ${POD_VERSION} is on trunk; treating post-publish verification failure as success"
+            echo "✅ ${POD_NAME} ${POD_VERSION} published (recovered from post-publish verification timeout)" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "::error::pod trunk push failed (exit ${PUSH_EXIT}) and ${POD_VERSION} is not on trunk"
+          exit $PUSH_EXIT
 

--- a/.github/workflows/publish-swift-utils.yml
+++ b/.github/workflows/publish-swift-utils.yml
@@ -140,7 +140,7 @@ jobs:
           fi
 
           echo "::warning::pod trunk push exited ${PUSH_EXIT} — checking whether ${POD_NAME} ${POD_VERSION} landed on trunk anyway"
-          TRUNK_JSON=$(curl -sf --retry 3 --retry-delay 2 \
+          TRUNK_JSON=$(curl -sf --max-time 30 --retry 3 --retry-delay 2 \
             "https://trunk.cocoapods.org/api/v1/pods/${POD_NAME}") || {
               echo "::error::pod trunk push failed (exit ${PUSH_EXIT}) and trunk API unreachable"
               exit $PUSH_EXIT

--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -127,7 +127,7 @@ jobs:
           fi
 
           echo "::warning::pod trunk push exited ${PUSH_EXIT} — checking whether ${POD_NAME} ${POD_VERSION} landed on trunk anyway"
-          TRUNK_JSON=$(curl -sf --retry 3 --retry-delay 2 \
+          TRUNK_JSON=$(curl -sf --max-time 30 --retry 3 --retry-delay 2 \
             "https://trunk.cocoapods.org/api/v1/pods/${POD_NAME}") || {
               echo "::error::pod trunk push failed (exit ${PUSH_EXIT}) and trunk API unreachable"
               exit $PUSH_EXIT

--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -109,6 +109,37 @@ jobs:
       - name: Publish CocoaPods
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+          POD_NAME: YttriumWrapper
+          POD_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          pod trunk push YttriumWrapper.podspec --allow-warnings
+          # pod trunk push is "publish, then verify the LICENSE URL via GitHub
+          # API". When that post-publish verification times out the spec has
+          # already been accepted but the command exits non-zero, and any
+          # retry fails with "duplicate entry". Detect that case and treat it
+          # as success.
+          set +e
+          pod trunk push "${POD_NAME}.podspec" --allow-warnings
+          PUSH_EXIT=$?
+          set -e
+
+          if [ $PUSH_EXIT -eq 0 ]; then
+            exit 0
+          fi
+
+          echo "::warning::pod trunk push exited ${PUSH_EXIT} — checking whether ${POD_NAME} ${POD_VERSION} landed on trunk anyway"
+          TRUNK_JSON=$(curl -sf --retry 3 --retry-delay 2 \
+            "https://trunk.cocoapods.org/api/v1/pods/${POD_NAME}") || {
+              echo "::error::pod trunk push failed (exit ${PUSH_EXIT}) and trunk API unreachable"
+              exit $PUSH_EXIT
+            }
+
+          if echo "$TRUNK_JSON" | jq -e --arg v "$POD_VERSION" \
+               '.versions | map(.name) | index($v)' >/dev/null; then
+            echo "::notice::${POD_NAME} ${POD_VERSION} is on trunk; treating post-publish verification failure as success"
+            echo "✅ ${POD_NAME} ${POD_VERSION} published (recovered from post-publish verification timeout)" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "::error::pod trunk push failed (exit ${PUSH_EXIT}) and ${POD_VERSION} is not on trunk"
+          exit $PUSH_EXIT
 


### PR DESCRIPTION
## Summary

Make the `Publish CocoaPods` step in both Swift release workflows idempotent against the post-publish GitHub-API timeout that left [YttriumUtilsWrapper 0.10.54's release run](https://github.com/reown-com/yttrium/actions/runs/26579754321) red despite the pod being live on CocoaPods.

### What `pod trunk push` actually does

It's two phases:

1. Upload the spec → trunk accepts it (idempotent within a `name + version`; re-pushes are rejected with `Unable to accept duplicate entry`).
2. Trunk calls GitHub's commit API to verify the `LICENSE` URL referenced by the spec.

If phase 2 times out, the spec has **already been accepted** in phase 1, but the command exits non-zero. Any retry then fails with the duplicate-entry error, so the job stays red even though the version is live.

### The 0.10.54 incident

- Spec accepted on trunk: `2026-05-28 14:08:29 UTC` (per [trunk.cocoapods.org/api/v1/pods/YttriumUtilsWrapper](https://trunk.cocoapods.org/api/v1/pods/YttriumUtilsWrapper))
- Workflow exited 1: `2026-05-28T14:08:43Z` (14 s later)
- Failure message: `Calling the GitHub commit API timed out. ... Unable to read the license file LICENSE for the spec YttriumUtilsWrapper (0.10.54)`
- Retry failed correctly: `Unable to accept duplicate entry for: YttriumUtilsWrapper (0.10.54)`

### The fix

After `pod trunk push`, if it exits non-zero, query `https://trunk.cocoapods.org/api/v1/pods/<PodName>` and check whether the version we tried to publish is present. If yes → emit a notice and exit 0. If no, or trunk is unreachable → propagate the original failure.

Applied identically to both:
- `.github/workflows/publish-swift-utils.yml` (`YttriumUtilsWrapper`)
- `.github/workflows/publish-swift.yml` (`YttriumWrapper`)

### Why this is safe

- Trunk rejects duplicates structurally — if `name + version` is on trunk, no third party could have pushed it. Either this run did, or a prior identical run did. The artifact at that version is *our* artifact either way.
- The fallback path only **reads** the trunk API; never re-pushes.
- Genuine failures (trunk unreachable, version genuinely absent) still propagate the original exit code.

## Test plan

- [ ] Workflow YAML parses (verified locally with `ruby -ryaml`)
- [ ] Next legitimate Swift release goes green on the happy path
- [ ] If a future post-publish timeout occurs, the run should pass with a `::notice::` in the step summary; verify the notice appears
- [ ] If trunk is genuinely unreachable, the step still fails (negative test — only verifiable by injecting a bad podspec name in a fork, not worth automating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)