### PR TITLE
ci(kotlin): enable yttrium/android-full so JNI initializeTls is exported

### DIFF
--- a/.github/workflows/release-kotlin-all.yml
+++ b/.github/workflows/release-kotlin-all.yml
@@ -62,7 +62,7 @@ jobs:
           cargo ndk -t ${{ matrix.target }} build \
             --profile=uniffi-release-kotlin \
             --no-default-features \
-            --features=android,erc6492_client,pay,uniffi/cli \
+            --features=android,yttrium/android-full,erc6492_client,pay,uniffi/cli \
             -p kotlin-ffi
       - name: Generate Kotlin bindings (aarch64 only)
         if: matrix.target == 'aarch64-linux-android'
@@ -70,7 +70,7 @@ jobs:
           rm -rf yttrium/kotlin-bindings
           cargo run \
             --no-default-features \
-            --features=android,erc6492_client,pay,uniffi/cli \
+            --features=android,yttrium/android-full,erc6492_client,pay,uniffi/cli \
             -p kotlin-ffi \
             --bin uniffi-bindgen generate \
             --library target/${{ matrix.target }}/uniffi-release-kotlin/libuniffi_yttrium.so \
@@ -141,7 +141,7 @@ jobs:
           cargo ndk -t ${{ matrix.target }} build \
             --profile=uniffi-release-kotlin \
             --no-default-features \
-            --features=android,chain_abstraction_client,solana,stacks,sui,ton,tron,eip155,uniffi/cli \
+            --features=android,yttrium/android-full,chain_abstraction_client,solana,stacks,sui,ton,tron,eip155,uniffi/cli \
             -p kotlin-ffi
       - name: Generate Kotlin bindings (aarch64 only)
         if: matrix.target == 'aarch64-linux-android'
@@ -149,7 +149,7 @@ jobs:
           rm -rf yttrium/kotlin-utils-bindings
           cargo run \
             --no-default-features \
-            --features=android,chain_abstraction_client,solana,stacks,sui,ton,tron,eip155,uniffi/cli \
+            --features=android,yttrium/android-full,chain_abstraction_client,solana,stacks,sui,ton,tron,eip155,uniffi/cli \
             -p kotlin-ffi \
             --bin uniffi-bindgen generate \
             --library target/${{ matrix.target }}/uniffi-release-kotlin/libuniffi_yttrium.so \
@@ -231,7 +231,7 @@ jobs:
           cargo ndk -t ${{ matrix.target }} build \
             --profile=uniffi-release-kotlin-wcpay \
             --no-default-features \
-            --features=android,pay,uniffi/cli \
+            --features=android,yttrium/android-full,pay,uniffi/cli \
             -p kotlin-ffi
       - name: Generate Kotlin bindings (aarch64 only)
         if: matrix.target == 'aarch64-linux-android'
@@ -239,7 +239,7 @@ jobs:
           rm -rf yttrium/kotlin-wcpay-bindings
           cargo run \
             --no-default-features \
-            --features=android,pay,uniffi/cli \
+            --features=android,yttrium/android-full,pay,uniffi/cli \
             -p kotlin-ffi \
             --bin uniffi-bindgen generate \
             --library target/${{ matrix.target }}/uniffi-release-kotlin-wcpay/libuniffi_yttrium.so \

--- a/.github/workflows/release-kotlin-utils.yml
+++ b/.github/workflows/release-kotlin-utils.yml
@@ -45,14 +45,14 @@ jobs:
           cargo ndk -t ${{ matrix.target }} build \
             --profile=uniffi-release-kotlin \
             --no-default-features \
-            --features=android,chain_abstraction_client,solana,stacks,sui,ton,tron,eip155,uniffi/cli
+            --features=android,yttrium/android-full,chain_abstraction_client,solana,stacks,sui,ton,tron,eip155,uniffi/cli
       - name: Generate Kotlin utils bindings (once, on aarch64 only)
         if: ${{ matrix.target == 'aarch64-linux-android' }}
         run: |
           rm -rf yttrium/kotlin-utils-bindings
           cargo run \
             --no-default-features \
-            --features=android,chain_abstraction_client,solana,stacks,sui,ton,tron,eip155,uniffi/cli \
+            --features=android,yttrium/android-full,chain_abstraction_client,solana,stacks,sui,ton,tron,eip155,uniffi/cli \
             -p kotlin-ffi \
             --bin uniffi-bindgen generate \
             --library target/${{ matrix.target }}/uniffi-release-kotlin/libuniffi_yttrium.so \

--- a/.github/workflows/release-kotlin-wcpay.yml
+++ b/.github/workflows/release-kotlin-wcpay.yml
@@ -50,7 +50,7 @@ jobs:
           cargo ndk -t ${{ matrix.target }} build \
             --profile=uniffi-release-kotlin-wcpay \
             --no-default-features \
-            --features=android,pay,uniffi/cli \
+            --features=android,yttrium/android-full,pay,uniffi/cli \
             -p kotlin-ffi
       - name: Generate Kotlin wcpay bindings (once, on aarch64 only)
         if: ${{ matrix.target == 'aarch64-linux-android' }}
@@ -58,7 +58,7 @@ jobs:
           rm -rf yttrium/kotlin-wcpay-bindings
           cargo run \
             --no-default-features \
-            --features=android,pay,uniffi/cli \
+            --features=android,yttrium/android-full,pay,uniffi/cli \
             -p kotlin-ffi \
             --bin uniffi-bindgen generate \
             --library target/${{ matrix.target }}/uniffi-release-kotlin-wcpay/libuniffi_yttrium.so \

--- a/.github/workflows/release-kotlin.yml
+++ b/.github/workflows/release-kotlin.yml
@@ -46,14 +46,14 @@ jobs:
           cargo ndk -t ${{ matrix.target }} build \
             --profile=uniffi-release-kotlin \
             --no-default-features \
-            --features=android,erc6492_client,pay,uniffi/cli
+            --features=android,yttrium/android-full,erc6492_client,pay,uniffi/cli
       - name: Generate Kotlin bindings (once, on aarch64 only)
         if: ${{ matrix.target == 'aarch64-linux-android' }}
         run: |
           rm -rf yttrium/kotlin-bindings
           cargo run \
             --no-default-features \
-            --features=android,erc6492_client,pay,uniffi/cli \
+            --features=android,yttrium/android-full,erc6492_client,pay,uniffi/cli \
             -p kotlin-ffi \
             --bin uniffi-bindgen generate \
             --library target/${{ matrix.target }}/uniffi-release-kotlin/libuniffi_yttrium.so \


### PR DESCRIPTION
## Summary

Restore the `Java_com_yttrium_*_initializeTls` JNI symbols in the published Kotlin AARs. They've been silently missing since `0.10.55` (the first Kotlin release after #360), causing `UnsatisfiedLinkError` on app launch in sample wallets that call `YttriumUtilsKt.initializeTls(applicationContext)`.

## What broke

PR #360 (\`feat(android): lean pay-only builds with 64% size reduction\`) intentionally split the Cargo features:

```toml
android       = [\"uniffi\", \"uniffi-rustls\", \"dep:jni\"]
android-full  = [\"android\", \"native\", \"dep:rustls-platform-verifier\"]
```

and gated the JNI \`initializeTls\` exports (\`crates/yttrium/src/lib.rs:81-111\`) on \`feature = \"android-full\"\`.

The four \`release-kotlin*.yml\` workflows were not updated and still passed \`--features=android,...\` only. Result: every Kotlin release built after #360 ships without the JNI entry point.

The bug went undetected until now because the previous Kotlin release (\`kotlin-utils-0.9.113\`, Nov 2025) predates #360 — \`0.10.55\` is the first one built with the lean feature set.

## Diagnosis

From a downstream consumer:

```
java.lang.UnsatisfiedLinkError:
  No implementation found for void com.yttrium.utils.YttriumUtilsKt.initializeTls
  (tried Java_com_yttrium_utils_YttriumUtilsKt_initializeTls ...)
  - is the library loaded, e.g. System.loadLibrary?
    at com.yttrium.utils.YttriumUtilsKt.initializeTls(Native Method)
    at com.reown.sample.wallet.domain.client.SuiUtils.init(Sui.kt:17)
    at com.reown.sample.wallet.WalletKitApplication.onCreate(...)
```

Confirmed by symbol inspection:
- `0.10.29` `libuniffi_yttrium_utils.so` exports `Java_com_yttrium_utils_YttriumUtilsKt_initializeTls` ✓
- `0.10.55` `libuniffi_yttrium_utils.so` has 553 dynamic symbols, **zero** `Java_*` exports ✗

## Fix

Add `yttrium/android-full` alongside the existing `android` feature in all 12 `cargo build` / `cargo run` invocations across the four workflows. Additive only — `android-full` is a superset of `android`. Validated locally on May 26: produced an AAR where `nm -D libuniffi_yttrium_utils.so | grep Java_` returned all three `initializeTls` symbols.

## Side effects (size)

`android-full` re-adds `rustls-platform-verifier` and `tokio-tungstenite` (`native` feature). Empirical from the local rebuild: `yttrium-utils.aar` ~17.0 MB → 17.7 MB.

This **undoes part of #360's size win** for the `wcpay` variant specifically — that variant was the whole motivation for the split (pay-only Kotlin builds from 11.3 MB → 2.16 MB). Restoring \`android-full\` on \`wcpay\` re-bloats it for no functional gain.

The clean follow-up is to **drop the `external fun initializeTls` declaration from `YttriumWcpayKt.kt`** and revert `wcpay` to `android` only. That's a consumer-facing API change for the pay-only SDK, so doing it here would gate the unblock on a separate review. Left as a TODO.

## Test plan

- [ ] After merge, cut `0.10.56` and run `nm -D` on the released `libuniffi_yttrium*.so` artifacts (all three) — expect `Java_com_yttrium_*_initializeTls` symbols
- [ ] Update the downstream sample wallet to \`0.10.56\`, confirm `WalletKitApplication.onCreate` no longer crashes
- [ ] Track AAR size deltas vs `0.10.55` and open a follow-up to restore the `wcpay` size win

## Related

- PR #360 — introduced the feature split
- Sister PR #506 (`ci(swift): treat post-publish trunk verification timeout as success`) — also a CI/release reliability fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)