### PR TITLE
fix(pay): remove option cache that could skip /fetch before /confirm

### DIFF
--- a/crates/yttrium/src/pay/json.rs
+++ b/crates/yttrium/src/pay/json.rs
@@ -516,10 +516,29 @@ mod tests {
             }]
         });
 
+        let fetch_response = serde_json::json!({
+            "actions": [{
+                "type": "walletRpc",
+                "data": {
+                    "chain_id": "eip155:1",
+                    "method": "eth_signTypedData_v4",
+                    "params": ["0xwallet", {"types": {}}]
+                }
+            }]
+        });
+
         Mock::given(method("POST"))
             .and(path("/v1/gateway/payment/pay_json_456/options"))
             .respond_with(
                 ResponseTemplate::new(200).set_body_json(&mock_response),
+            )
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/gateway/payment/pay_json_456/fetch"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(&fetch_response),
             )
             .mount(&mock_server)
             .await;

--- a/crates/yttrium/src/pay/mod.rs
+++ b/crates/yttrium/src/pay/mod.rs
@@ -783,7 +783,7 @@ pub struct PaymentOptionsResponse {
 
 // ==================== Client ====================
 
-use {parking_lot::RwLock, std::sync::OnceLock, url::Url};
+use {std::sync::OnceLock, url::Url};
 
 /// Applies common SDK config headers to any progenitor-generated request builder.
 /// Auth header logic:
@@ -807,18 +807,11 @@ macro_rules! with_sdk_config {
     }};
 }
 
-#[derive(Debug, Clone)]
-struct CachedPaymentOption {
-    option_id: String,
-    actions: Vec<types::Action>,
-}
-
 #[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
 pub struct WalletConnectPay {
     /// Lazily initialized API client (requires Tokio runtime)
     client: OnceLock<Client>,
     config: SdkConfig,
-    cached_options: RwLock<Vec<CachedPaymentOption>>,
     /// Lazily initialized HTTP client for error reporting (requires Tokio runtime)
     error_http_client: OnceLock<reqwest::Client>,
     /// Tracks if SdkInitialized event was sent (done on first API call, not constructor)
@@ -921,7 +914,6 @@ impl WalletConnectPay {
         Ok(Self {
             client: OnceLock::new(),
             config,
-            cached_options: RwLock::new(Vec::new()),
             error_http_client: OnceLock::new(),
             initialized_event_sent: OnceLock::new(),
             client_id,
@@ -929,7 +921,6 @@ impl WalletConnectPay {
     }
 
     /// Get payment options for given accounts
-    /// Also caches the options for use by get_actions
     pub async fn get_payment_options(
         &self,
         payment_link: String,
@@ -985,17 +976,6 @@ impl WalletConnectPay {
         let options = api_response.options.unwrap_or_default();
         pay_debug!("get_payment_options: success, {} options", options.len());
 
-        // Cache the options with their raw actions
-        let cached: Vec<CachedPaymentOption> = options
-            .iter()
-            .map(|o| CachedPaymentOption {
-                option_id: o.id.clone(),
-                actions: o.actions.clone(),
-            })
-            .collect();
-        let mut cache = self.cached_options.write();
-        *cache = cached;
-
         self.send_trace(
             observability::TraceEvent::PaymentOptionsReceived,
             &payment_id,
@@ -1009,8 +989,8 @@ impl WalletConnectPay {
     }
 
     /// Get required payment actions for a selected option
-    /// Returns cached actions if available, otherwise calls fetch to get them
-    /// Build action types are automatically resolved by calling the fetch endpoint
+    /// Always calls the fetch endpoint to claim the option server-side and
+    /// resolve any Build placeholders into concrete WalletRpc actions.
     pub async fn get_required_payment_actions(
         &self,
         payment_id: String,
@@ -1027,52 +1007,19 @@ impl WalletConnectPay {
             &payment_id,
         );
 
-        let raw_actions = {
-            let cache = self.cached_options.read();
-            cache
-                .iter()
-                .find(|o| o.option_id == option_id)
-                .map(|o| o.actions.clone())
-        };
-        let raw_actions = match raw_actions {
-            Some(actions) if !actions.is_empty() => {
-                pay_debug!(
-                    "get_required_payment_actions: using cached actions"
+        let raw_actions = self
+            .fetch(&payment_id, &option_id, String::new())
+            .await
+            .map_err(|e| {
+                pay_error!("get_required_payment_actions fetch: {:?}", e);
+                let err = map_pay_error_to_request_error(e);
+                self.report_error(&err, &payment_id);
+                self.send_trace(
+                    observability::TraceEvent::RequiredActionsFailed,
+                    &payment_id,
                 );
-                actions
-            }
-            _ => {
-                pay_debug!("get_required_payment_actions: fetching actions");
-                let fetched = self
-                    .fetch(&payment_id, &option_id, String::new())
-                    .await
-                    .map_err(|e| {
-                        pay_error!(
-                            "get_required_payment_actions fetch: {:?}",
-                            e
-                        );
-                        let err = map_pay_error_to_request_error(e);
-                        self.report_error(&err, &payment_id);
-                        self.send_trace(
-                            observability::TraceEvent::RequiredActionsFailed,
-                            &payment_id,
-                        );
-                        err
-                    })?;
-                let mut cache = self.cached_options.write();
-                if let Some(cached) =
-                    cache.iter_mut().find(|o| o.option_id == option_id)
-                {
-                    cached.actions = fetched.clone();
-                } else {
-                    cache.push(CachedPaymentOption {
-                        option_id: option_id.clone(),
-                        actions: fetched.clone(),
-                    });
-                }
-                fetched
-            }
-        };
+                err
+            })?;
         let result =
             self.resolve_actions(&payment_id, &option_id, raw_actions).await;
         match &result {
@@ -2126,10 +2073,29 @@ mod tests {
             ]
         });
 
+        let fetch_response = serde_json::json!({
+            "actions": [{
+                "type": "walletRpc",
+                "data": {
+                    "chain_id": "eip155:8453",
+                    "method": "eth_signTypedData_v4",
+                    "params": ["0xabc", "{\"typed\":\"data\"}"]
+                }
+            }]
+        });
+
         Mock::given(method("POST"))
             .and(path("/v1/gateway/payment/pay_123/options"))
             .respond_with(
                 ResponseTemplate::new(200).set_body_json(&mock_response),
+            )
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/gateway/payment/pay_123/fetch"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(&fetch_response),
             )
             .mount(&mock_server)
             .await;


### PR DESCRIPTION
## Summary

Removes the in-memory `cached_options` cache on `WalletConnectPay` in the Pay module. The cache was the most plausible cause of the iOS `confirmPayment` "InvalidOption" (HTTP 400) bug that did not repro on RN.

## The bug

**Symptom:** On iOS, a user scans a payment code, picks an option, presses Pay, and gets "invalid option id." After the failure, re-scanning the payment code and re-selecting the option makes the next attempt succeed. RN doesn't repro it.

## Root cause analysis

`WalletConnectPay` kept a singleton `cached_options: RwLock<Vec<CachedPaymentOption>>` populated by `getPaymentOptions` (each entry: `option_id` + raw `actions`).

The flow on the wire is two-step:
1. `POST /options` — returns options with embedded `actions[]`. Each action is either `WalletRpc` (ready to sign) or `Build` (placeholder; must be resolved via `POST /fetch`).
2. `POST /fetch` — resolves a `Build` placeholder into concrete `WalletRpc` actions.

When the caller then invoked `getRequiredPaymentActions`, the implementation looked the `option_id` up in the cache. If the cached actions were already pure `WalletRpc` (no `Build`), the function **returned the cached actions without calling `/fetch`** — the entire roundtrip was skipped, and `/confirm` became the first server-side touch of that `option_id`.

That timing matches the failure. I don't yet know exactly *why* the backend rejects an `option_id` that hasn't been touched by `/fetch` (quote-locking, session state, eventual consistency, or something else) — that's worth a follow-up with the Pay backend team. But aligning iOS's behavior to RN's is the right move regardless.

## Comparison with the RN implementation

The RN reference wallet (`react-native-examples/wallets/rn_cli_wallet`) uses `@reown/walletkit` v1.5.5, which calls the Pay endpoints directly with **no client-side cache** between them:

- `payClient.getPaymentOptions()`
- `payClient.getRequiredPaymentActions()` — always hits the network
- `payClient.confirmPayment()`

Verified by reading `src/store/PaymentStore.ts`: `fetchPaymentActions()` always calls `payClient.getRequiredPaymentActions()` with no client-side storage of actions. The only state it keeps is a request-deduplication sequence number and fee estimates — neither of which short-circuit the network call.

So on RN, `/fetch` always runs before `/confirm`. On iOS, it sometimes didn't. That is the clearest behavioral difference between the two paths, and it's exactly the kind of difference that produces "works on RN, fails on iOS."

## The fix

Removes the cache entirely.

- Drop the `CachedPaymentOption` struct and the `cached_options` field on `WalletConnectPay`.
- Drop the cache write in `getPaymentOptions`.
- `getRequiredPaymentActions` now unconditionally calls `self.fetch(payment_id, option_id, "")` and passes the result to `resolve_actions`.
- Drop the `parking_lot::RwLock` import in `pay/mod.rs` (no longer used here).
- Update `test_get_required_payment_actions_success` (in both `mod.rs` and `json.rs`) to mock `/fetch`, since the path no longer short-circuits on a cache hit.

## Why the cache wasn't worth keeping

Beyond the bug, the cache had design issues that made it a poor fit:

- **One-shot path.** `getRequiredPaymentActions` is called exactly once per payment selection. There's no scenario where the cache prevents repeated calls — at best it saved a single roundtrip in a narrow case (inline `WalletRpc` actions only).
- **Cross-session leakage.** Keyed by `option_id` only, with no `payment_id` scope, and stored on the SDK singleton — so stale option IDs could pile up across payment sessions and `getRequiredPaymentActions` could push fresh option IDs back into the cache on cache miss.
- **Hidden coupling.** The public `PaymentOption.actions` filters out `Build` variants (see `mod.rs:706-711`), so the cache was the only place the raw `Build` actions lived after `getPaymentOptions` returned. This is exactly the kind of state coupling that produced this bug.

The post-fix flow is the same one RN already uses successfully.

## Verification

- `cargo check --features=full -p yttrium` — clean.
- `cargo test --features=full --lib -p yttrium pay::` — **82 passed, 0 failed, 1 ignored**.
- `cargo +nightly fmt --all -- --check` — clean.

## Caveats / next steps

- I have **not** verified on a device with the original repro yet. Marking this draft so we can build and validate end-to-end before merging.
- Needs a Yttrium patch release and a Swift SDK bump to land on iOS.
- Follow-up with the Pay backend team to confirm why an `option_id` that has not been touched by `/fetch` fails `/confirm` — would be good to either document that contract or fix it server-side so the dependency is explicit.

## Test plan

- [ ] Build the Swift XCFramework (`just swift`)
- [ ] Run the original iOS repro: scan payment code → select option → press Pay
- [ ] Confirm `/confirm` succeeds on the first attempt
- [ ] Sanity check on Android via Kotlin bindings

🤖 Generated with [Claude Code](https://claude.com/claude-code)