### PR TITLE
feat(pay): map sanctioned_user to ComplianceFailed in confirm_payment

### DIFF
--- a/crates/yttrium/src/pay/json.rs
+++ b/crates/yttrium/src/pay/json.rs
@@ -166,6 +166,9 @@ impl From<ConfirmPaymentError> for PayJsonError {
             ConfirmPaymentError::InvalidSignature(msg) => {
                 Self::InvalidSignature(msg)
             }
+            ConfirmPaymentError::ComplianceFailed(msg) => {
+                Self::ComplianceFailed(msg)
+            }
             ConfirmPaymentError::RouteExpired(msg) => Self::RouteExpired(msg),
             ConfirmPaymentError::QuoteExpired(msg) => Self::QuoteExpired(msg),
             ConfirmPaymentError::UnsupportedMethod(msg) => {

--- a/crates/yttrium/src/pay/mod.rs
+++ b/crates/yttrium/src/pay/mod.rs
@@ -247,6 +247,8 @@ pub enum ConfirmPaymentError {
     InvalidOption(String),
     #[error("Invalid signature: {0}")]
     InvalidSignature(String),
+    #[error("Compliance failed: {0}")]
+    ComplianceFailed(String),
     #[error("Route expired: {0}")]
     RouteExpired(String),
     #[error("Quote expired: {0}")]
@@ -276,6 +278,7 @@ impl error_reporting::HasErrorType for ConfirmPaymentError {
             Self::PaymentExpired(_) => "PaymentExpired",
             Self::InvalidOption(_) => "InvalidOption",
             Self::InvalidSignature(_) => "InvalidSignature",
+            Self::ComplianceFailed(_) => "ComplianceFailed",
             Self::RouteExpired(_) => "RouteExpired",
             Self::QuoteExpired(_) => "QuoteExpired",
             Self::NoConnection(_) => "NoConnection",
@@ -1512,14 +1515,17 @@ fn map_payment_options_error(
     match e {
         progenitor_client::Error::ErrorResponse(resp) => {
             let status = resp.status().as_u16();
-            let msg = format!("{}: {}", status, resp.into_inner().message);
+            let inner = resp.into_inner();
+            let msg = format!("{}: {}", status, inner.message);
+            if inner.code == types::ErrorCode::SanctionedUser {
+                return GetPaymentOptionsError::ComplianceFailed(msg);
+            }
             match status {
                 404 => GetPaymentOptionsError::PaymentNotFound(msg),
                 400 => GetPaymentOptionsError::InvalidRequest(msg),
                 410 => GetPaymentOptionsError::PaymentExpired(msg),
                 422 => GetPaymentOptionsError::InvalidAccount(msg),
                 429 => GetPaymentOptionsError::RateLimited(msg),
-                451 => GetPaymentOptionsError::ComplianceFailed(msg),
                 _ => GetPaymentOptionsError::Http(msg),
             }
         }
@@ -1532,7 +1538,6 @@ fn map_payment_options_error(
                 410 => GetPaymentOptionsError::PaymentExpired(msg),
                 422 => GetPaymentOptionsError::InvalidAccount(msg),
                 429 => GetPaymentOptionsError::RateLimited(msg),
-                451 => GetPaymentOptionsError::ComplianceFailed(msg),
                 _ => GetPaymentOptionsError::Http(msg),
             }
         }
@@ -1568,6 +1573,9 @@ fn map_confirm_payment_error(
             let status = resp.status().as_u16();
             let inner = resp.into_inner();
             let msg = format!("{}: {}", status, inner.message);
+            if inner.code == types::ErrorCode::SanctionedUser {
+                return ConfirmPaymentError::ComplianceFailed(msg);
+            }
             if inner.code == types::ErrorCode::QuoteExpired {
                 return ConfirmPaymentError::QuoteExpired(msg);
             }
@@ -3003,6 +3011,40 @@ mod tests {
         assert!(
             matches!(result, Err(ConfirmPaymentError::PollingTimeout(_))),
             "Expected PollingTimeout, got {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_confirm_payment_sanctioned_user_returns_compliance_failed() {
+        let mock_server = MockServer::start().await;
+        let error_response = serde_json::json!({
+            "code": "sanctioned_user",
+            "message": "Wallet is sanctioned"
+        });
+        Mock::given(method("POST"))
+            .and(path("/v1/gateway/payment/pay_sanctioned/confirm"))
+            .respond_with(
+                ResponseTemplate::new(400).set_body_json(&error_response),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let client =
+            WalletConnectPay::new(test_config(mock_server.uri())).unwrap();
+        let result = client
+            .confirm_payment(
+                "pay_sanctioned".to_string(),
+                "opt_1".to_string(),
+                vec!["0x123".to_string()],
+                None,
+                Some(100),
+            )
+            .await;
+
+        assert!(
+            matches!(result, Err(ConfirmPaymentError::ComplianceFailed(_))),
+            "Expected ComplianceFailed, got {:?}",
             result
         );
     }

--- a/platforms/swift/Sources/Yttrium/yttrium.swift
+++ b/platforms/swift/Sources/Yttrium/yttrium.swift
@@ -2327,6 +2327,8 @@ public enum ConfirmPaymentError: Swift.Error, Equatable, Hashable, Foundation.Lo
     )
     case InvalidSignature(String
     )
+    case ComplianceFailed(String
+    )
     case RouteExpired(String
     )
     case QuoteExpired(String
@@ -2388,34 +2390,37 @@ public struct FfiConverterTypeConfirmPaymentError: FfiConverterRustBuffer {
         case 4: return .InvalidSignature(
             try FfiConverterString.read(from: &buf)
             )
-        case 5: return .RouteExpired(
+        case 5: return .ComplianceFailed(
             try FfiConverterString.read(from: &buf)
             )
-        case 6: return .QuoteExpired(
+        case 6: return .RouteExpired(
             try FfiConverterString.read(from: &buf)
             )
-        case 7: return .NoConnection(
+        case 7: return .QuoteExpired(
             try FfiConverterString.read(from: &buf)
             )
-        case 8: return .RequestTimeout(
+        case 8: return .NoConnection(
             try FfiConverterString.read(from: &buf)
             )
-        case 9: return .ConnectionFailed(
+        case 9: return .RequestTimeout(
             try FfiConverterString.read(from: &buf)
             )
-        case 10: return .RateLimited(
+        case 10: return .ConnectionFailed(
             try FfiConverterString.read(from: &buf)
             )
-        case 11: return .Http(
+        case 11: return .RateLimited(
             try FfiConverterString.read(from: &buf)
             )
-        case 12: return .InternalError(
+        case 12: return .Http(
             try FfiConverterString.read(from: &buf)
             )
-        case 13: return .UnsupportedMethod(
+        case 13: return .InternalError(
             try FfiConverterString.read(from: &buf)
             )
-        case 14: return .PollingTimeout(
+        case 14: return .UnsupportedMethod(
+            try FfiConverterString.read(from: &buf)
+            )
+        case 15: return .PollingTimeout(
             try FfiConverterString.read(from: &buf)
             )
 
@@ -2450,53 +2455,58 @@ public struct FfiConverterTypeConfirmPaymentError: FfiConverterRustBuffer {
             FfiConverterString.write(v1, into: &buf)
             
         
-        case let .RouteExpired(v1):
+        case let .ComplianceFailed(v1):
             writeInt(&buf, Int32(5))
             FfiConverterString.write(v1, into: &buf)
             
         
-        case let .QuoteExpired(v1):
+        case let .RouteExpired(v1):
             writeInt(&buf, Int32(6))
             FfiConverterString.write(v1, into: &buf)
             
         
-        case let .NoConnection(v1):
+        case let .QuoteExpired(v1):
             writeInt(&buf, Int32(7))
             FfiConverterString.write(v1, into: &buf)
             
         
-        case let .RequestTimeout(v1):
+        case let .NoConnection(v1):
             writeInt(&buf, Int32(8))
             FfiConverterString.write(v1, into: &buf)
             
         
-        case let .ConnectionFailed(v1):
+        case let .RequestTimeout(v1):
             writeInt(&buf, Int32(9))
             FfiConverterString.write(v1, into: &buf)
             
         
-        case let .RateLimited(v1):
+        case let .ConnectionFailed(v1):
             writeInt(&buf, Int32(10))
             FfiConverterString.write(v1, into: &buf)
             
         
-        case let .Http(v1):
+        case let .RateLimited(v1):
             writeInt(&buf, Int32(11))
             FfiConverterString.write(v1, into: &buf)
             
         
-        case let .InternalError(v1):
+        case let .Http(v1):
             writeInt(&buf, Int32(12))
             FfiConverterString.write(v1, into: &buf)
             
         
-        case let .UnsupportedMethod(v1):
+        case let .InternalError(v1):
             writeInt(&buf, Int32(13))
             FfiConverterString.write(v1, into: &buf)
             
         
-        case let .PollingTimeout(v1):
+        case let .UnsupportedMethod(v1):
             writeInt(&buf, Int32(14))
+            FfiConverterString.write(v1, into: &buf)
+            
+        
+        case let .PollingTimeout(v1):
+            writeInt(&buf, Int32(15))
             FfiConverterString.write(v1, into: &buf)
             
         }


### PR DESCRIPTION
## Summary

When a wallet is sanctioned, the backend returns the `sanctioned_user` error code. On `confirm_payment` this previously fell through to the opaque `ConfirmPaymentError::Http(...)` catch-all, indistinguishable from any other HTTP failure. This adds a dedicated typed error so callers can surface a proper compliance message.

## Changes

- **New `ConfirmPaymentError::ComplianceFailed` variant** + `HasErrorType` arm, so a sanctioned wallet on `confirm_payment` returns a typed error instead of `Http(...)`.
- **Detect compliance by error `code`, not HTTP status.** `451` is not documented anywhere in the OpenAPI spec, whereas `sanctioned_user` is a defined `ErrorCode`. Both `confirm_payment` and `get_payment_options` now branch on `inner.code == ErrorCode::SanctionedUser`; the speculative `451 => ComplianceFailed` mappings in `get_payment_options` are removed.
- **JSON wrapper:** map `ConfirmPaymentError::ComplianceFailed` → `PayJsonError::ComplianceFailed` (the wrapper variant already existed).
- **Swift FFI:** regenerated `yttrium.swift` to expose the new variant (diff isolated to `ConfirmPaymentError`).
- **Test:** `test_confirm_payment_sanctioned_user_returns_compliance_failed` mocks a `sanctioned_user` body and asserts `ComplianceFailed`.

## Notes

- The detection keys purely on the `code` field, so the HTTP status the backend uses doesn't matter as long as it's one progenitor decodes into a typed `ErrorResponse` (the documented `400/401/404/500`). If the backend sends `sanctioned_user` on a status outside those, we'd need to add it to the spec's documented responses.
- Kotlin bindings are generated at release time (not committed), so no regeneration was needed there.

## Verification

- `cargo check --features=full` — clean
- New unit test passes
- `just lint` (nightly fmt + clippy `-D warnings`) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)