### PR TITLE
refactor(pay): remove ComplianceFailed error and sanctioned_user handling

### DIFF
--- a/crates/yttrium/src/pay/json.rs
+++ b/crates/yttrium/src/pay/json.rs
@@ -43,8 +43,6 @@ pub enum PayJsonError {
     InvalidRequest(String),
     #[error("Payment not ready: {0}")]
     PaymentNotReady(String),
-    #[error("Compliance failed: {0}")]
-    ComplianceFailed(String),
     // GetPaymentRequest specific errors
     #[error("Fetch error: {0}")]
     FetchError(String),
@@ -106,9 +104,6 @@ impl From<GetPaymentOptionsError> for PayJsonError {
                 Self::PaymentNotReady(msg)
             }
             GetPaymentOptionsError::RateLimited(msg) => Self::RateLimited(msg),
-            GetPaymentOptionsError::ComplianceFailed(msg) => {
-                Self::ComplianceFailed(msg)
-            }
         }
     }
 }

--- a/crates/yttrium/src/pay/mod.rs
+++ b/crates/yttrium/src/pay/mod.rs
@@ -158,8 +158,6 @@ pub enum GetPaymentOptionsError {
     PaymentNotReady(String),
     #[error("Invalid account: {0}")]
     InvalidAccount(String),
-    #[error("Compliance failed: {0}")]
-    ComplianceFailed(String),
     #[error("No network connection: {0}")]
     NoConnection(String),
     #[error("Request timed out: {0}")]
@@ -183,7 +181,6 @@ impl error_reporting::HasErrorType for GetPaymentOptionsError {
             Self::OptionNotFound(_) => "OptionNotFound",
             Self::PaymentNotReady(_) => "PaymentNotReady",
             Self::InvalidAccount(_) => "InvalidAccount",
-            Self::ComplianceFailed(_) => "ComplianceFailed",
             Self::NoConnection(_) => "NoConnection",
             Self::RequestTimeout(_) => "RequestTimeout",
             Self::ConnectionFailed(_) => "ConnectionFailed",
@@ -1519,7 +1516,6 @@ fn map_payment_options_error(
                 410 => GetPaymentOptionsError::PaymentExpired(msg),
                 422 => GetPaymentOptionsError::InvalidAccount(msg),
                 429 => GetPaymentOptionsError::RateLimited(msg),
-                451 => GetPaymentOptionsError::ComplianceFailed(msg),
                 _ => GetPaymentOptionsError::Http(msg),
             }
         }
@@ -1532,7 +1528,6 @@ fn map_payment_options_error(
                 410 => GetPaymentOptionsError::PaymentExpired(msg),
                 422 => GetPaymentOptionsError::InvalidAccount(msg),
                 429 => GetPaymentOptionsError::RateLimited(msg),
-                451 => GetPaymentOptionsError::ComplianceFailed(msg),
                 _ => GetPaymentOptionsError::Http(msg),
             }
         }

--- a/platforms/swift/Sources/Yttrium/yttrium.swift
+++ b/platforms/swift/Sources/Yttrium/yttrium.swift
@@ -2535,8 +2535,6 @@ public enum GetPaymentOptionsError: Swift.Error, Equatable, Hashable, Foundation
     )
     case InvalidAccount(String
     )
-    case ComplianceFailed(String
-    )
     case NoConnection(String
     )
     case RequestTimeout(String
@@ -2596,25 +2594,22 @@ public struct FfiConverterTypeGetPaymentOptionsError: FfiConverterRustBuffer {
         case 6: return .InvalidAccount(
             try FfiConverterString.read(from: &buf)
             )
-        case 7: return .ComplianceFailed(
+        case 7: return .NoConnection(
             try FfiConverterString.read(from: &buf)
             )
-        case 8: return .NoConnection(
+        case 8: return .RequestTimeout(
             try FfiConverterString.read(from: &buf)
             )
-        case 9: return .RequestTimeout(
+        case 9: return .ConnectionFailed(
             try FfiConverterString.read(from: &buf)
             )
-        case 10: return .ConnectionFailed(
+        case 10: return .RateLimited(
             try FfiConverterString.read(from: &buf)
             )
-        case 11: return .RateLimited(
+        case 11: return .Http(
             try FfiConverterString.read(from: &buf)
             )
-        case 12: return .Http(
-            try FfiConverterString.read(from: &buf)
-            )
-        case 13: return .InternalError(
+        case 12: return .InternalError(
             try FfiConverterString.read(from: &buf)
             )
 
@@ -2659,38 +2654,33 @@ public struct FfiConverterTypeGetPaymentOptionsError: FfiConverterRustBuffer {
             FfiConverterString.write(v1, into: &buf)
             
         
-        case let .ComplianceFailed(v1):
+        case let .NoConnection(v1):
             writeInt(&buf, Int32(7))
             FfiConverterString.write(v1, into: &buf)
             
         
-        case let .NoConnection(v1):
+        case let .RequestTimeout(v1):
             writeInt(&buf, Int32(8))
             FfiConverterString.write(v1, into: &buf)
             
         
-        case let .RequestTimeout(v1):
+        case let .ConnectionFailed(v1):
             writeInt(&buf, Int32(9))
             FfiConverterString.write(v1, into: &buf)
             
         
-        case let .ConnectionFailed(v1):
+        case let .RateLimited(v1):
             writeInt(&buf, Int32(10))
             FfiConverterString.write(v1, into: &buf)
             
         
-        case let .RateLimited(v1):
+        case let .Http(v1):
             writeInt(&buf, Int32(11))
             FfiConverterString.write(v1, into: &buf)
             
         
-        case let .Http(v1):
-            writeInt(&buf, Int32(12))
-            FfiConverterString.write(v1, into: &buf)
-            
-        
         case let .InternalError(v1):
-            writeInt(&buf, Int32(13))
+            writeInt(&buf, Int32(12))
             FfiConverterString.write(v1, into: &buf)
             
         }
@@ -3165,8 +3155,6 @@ public enum PayJsonError: Swift.Error, Equatable, Hashable, Foundation.Localized
     )
     case PaymentNotReady(String
     )
-    case ComplianceFailed(String
-    )
     case FetchError(String
     )
     case InvalidOption(String
@@ -3255,28 +3243,25 @@ public struct FfiConverterTypePayJsonError: FfiConverterRustBuffer {
         case 15: return .PaymentNotReady(
             try FfiConverterString.read(from: &buf)
             )
-        case 16: return .ComplianceFailed(
+        case 16: return .FetchError(
             try FfiConverterString.read(from: &buf)
             )
-        case 17: return .FetchError(
+        case 17: return .InvalidOption(
             try FfiConverterString.read(from: &buf)
             )
-        case 18: return .InvalidOption(
+        case 18: return .InvalidSignature(
             try FfiConverterString.read(from: &buf)
             )
-        case 19: return .InvalidSignature(
+        case 19: return .RouteExpired(
             try FfiConverterString.read(from: &buf)
             )
-        case 20: return .RouteExpired(
+        case 20: return .QuoteExpired(
             try FfiConverterString.read(from: &buf)
             )
-        case 21: return .QuoteExpired(
+        case 21: return .UnsupportedMethod(
             try FfiConverterString.read(from: &buf)
             )
-        case 22: return .UnsupportedMethod(
-            try FfiConverterString.read(from: &buf)
-            )
-        case 23: return .PollingTimeout(
+        case 22: return .PollingTimeout(
             try FfiConverterString.read(from: &buf)
             )
 
@@ -3366,43 +3351,38 @@ public struct FfiConverterTypePayJsonError: FfiConverterRustBuffer {
             FfiConverterString.write(v1, into: &buf)
             
         
-        case let .ComplianceFailed(v1):
+        case let .FetchError(v1):
             writeInt(&buf, Int32(16))
             FfiConverterString.write(v1, into: &buf)
             
         
-        case let .FetchError(v1):
+        case let .InvalidOption(v1):
             writeInt(&buf, Int32(17))
             FfiConverterString.write(v1, into: &buf)
             
         
-        case let .InvalidOption(v1):
+        case let .InvalidSignature(v1):
             writeInt(&buf, Int32(18))
             FfiConverterString.write(v1, into: &buf)
             
         
-        case let .InvalidSignature(v1):
+        case let .RouteExpired(v1):
             writeInt(&buf, Int32(19))
             FfiConverterString.write(v1, into: &buf)
             
         
-        case let .RouteExpired(v1):
+        case let .QuoteExpired(v1):
             writeInt(&buf, Int32(20))
             FfiConverterString.write(v1, into: &buf)
             
         
-        case let .QuoteExpired(v1):
+        case let .UnsupportedMethod(v1):
             writeInt(&buf, Int32(21))
             FfiConverterString.write(v1, into: &buf)
             
         
-        case let .UnsupportedMethod(v1):
-            writeInt(&buf, Int32(22))
-            FfiConverterString.write(v1, into: &buf)
-            
-        
         case let .PollingTimeout(v1):
-            writeInt(&buf, Int32(23))
+            writeInt(&buf, Int32(22))
             FfiConverterString.write(v1, into: &buf)
             
         }


### PR DESCRIPTION
## Summary

Removes all special-casing of sanctioned users in the pay module. Sanctioned-wallet responses now surface through the **generic error path** instead of a dedicated `ComplianceFailed` error.

This supersedes #510 (which added `ComplianceFailed` to `confirm_payment`); the plan changed to show the generic error, so we remove the handling entirely — including the variants that pre-existed that PR.

## Changes

- Remove the `ComplianceFailed` variant from `ConfirmPaymentError`, `GetPaymentOptionsError`, and `PayJsonError`.
- Remove the `sanctioned_user` (`ErrorCode::SanctionedUser`) / HTTP `451` detection from the `confirm_payment` and `get_payment_options` error mappers.
- Regenerate the Swift FFI bindings (`ComplianceFailed` removed from all affected enums, discriminants renumbered).

## Verification

- `cargo check --features=full` — clean
- `just lint` (nightly fmt + clippy `-D warnings`) — clean
- 82 pay unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)